### PR TITLE
0.7.1: ship mcp/ in the npm package

### DIFF
--- a/bin/install.js
+++ b/bin/install.js
@@ -88,7 +88,11 @@ for (const t of targets) {
     }
     fs.rmSync(t.dir, { recursive: true, force: true });
     fs.mkdirSync(t.dir, { recursive: true });
-    for (const item of PAYLOAD) copyRecursive(path.join(ROOT, item), path.join(t.dir, item));
+    for (const item of PAYLOAD) {
+      const src = path.join(ROOT, item);
+      if (!fs.existsSync(src)) { if (item !== 'SKILL.md' && item !== 'scripts') continue; throw new Error(`missing ${item} in package`); }
+      copyRecursive(src, path.join(t.dir, item));
+    }
     console.log(`installed ${t.label}: ${t.dir}`);
   } catch (err) {
     failed = true;

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ffmpeg-skill",
-  "version": "0.7.0",
+  "version": "0.7.1",
   "description": "Agent Skill that lets coding agents (Claude Code, Cursor, Codex) do professional video editing with local FFmpeg: MCP server, batch processing, declarative project rendering, brand kits, motion-graphics templates, HTML delivery reports, scene detection, delivery checks, cut, silence removal, transitions, multicam, captions, sync with drift correction, HDR to SDR, LUTs, audio clean-up and ducking, loudness, platform exports. No API keys, no cloud, no dependencies.",
   "keywords": ["ffmpeg", "video", "agent-skill", "claude-code", "cursor", "codex", "skill", "video-editing"],
   "license": "MIT",
@@ -17,6 +17,7 @@
   "files": [
     "bin/",
     "scripts/",
+    "mcp/",
     "SKILL.md",
     "README.md",
     "LICENSE"


### PR DESCRIPTION
## Summary

`npx ffmpeg-skill@0.7.0` failed: `package.json` `files` did not include `mcp/`, so the installer hit ENOENT. This adds `mcp/` to the package and makes the installer skip optional payload entries instead of aborting.

## Verification

- `npm pack --dry-run` lists `mcp/server.py` (51 files)
- `node bin/install.js` installs SKILL.md, scripts/ and mcp/

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013tPrsGXLuaGU7t643QNUZs

---
_Generated by [Claude Code](https://claude.ai/code/session_013tPrsGXLuaGU7t643QNUZs)_