### PR TITLE
docs: add GitHub Sponsors support

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,0 +1,1 @@
+github: kajisho5

--- a/README.md
+++ b/README.md
@@ -163,6 +163,10 @@ python3 evals/run.py --list     # routing eval prompts (see evals/)
 node bin/install.js --dir /tmp/skills   # try the installer without touching ~/.claude
 ```
 
+## Support
+
+If this skill saves you time, you can help keep it maintained through [GitHub Sponsors](https://github.com/sponsors/kajisho5). Issues and pull requests are just as welcome.
+
 ## License
 
 [MIT](LICENSE)


### PR DESCRIPTION
Adds the GitHub Sponsors entry points for this repository.

- `.github/FUNDING.yml` with `github: kajisho5`, so the Sponsor button appears once the Sponsors profile is approved.
- A short **Support** section in `README.md` (above License) linking to https://github.com/sponsors/kajisho5, in the existing tone; the install and usage sections are untouched.
- No changes to scripts, tests, the installer or the license.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013tPrsGXLuaGU7t643QNUZs

---
_Generated by [Claude Code](https://claude.ai/code/session_013tPrsGXLuaGU7t643QNUZs)_