### PR TITLE
multicam.py: warn on low-confidence cameras; document sync != lip sync

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased — FFmpeg 8+ / Windows compatibility for caption and color
 
+- **`multicam.py` low-confidence warning.** `sync.py` warns on stderr when its cross-correlation confidence is below 0.1 ("check that both files contain the same audio event"); `multicam.py` used the same measurement per camera but never warned, even though it applies the offset to a rendered cut rather than just reporting it. It now warns per camera below the same threshold. SKILL.md's existing "check `confidence` before trusting a sync" guidance now names `multicam.py`'s per-camera confidence explicitly.
+- **`sync.py`/`multicam.py` documentation: audio sync is not lip sync.** Both align audio tracks to each other by cross-correlation; neither has ever done any face or mouth detection, and a high `confidence` only means the audio matched well, not that the final picture looks in sync. This was previously undocumented; `sync.py`'s docstring, `multicam.py`'s docstring and SKILL.md now say so explicitly. No behaviour change.
 - **`export.py --preset copy`.** Every existing preset re-encodes (even `prores`/`h265`, which
   keep the source resolution). A caller with nothing to change — the deliverable already matches
   the source, no platform target — had no way to get a real, delivered file out of `export.py`

--- a/README.md
+++ b/README.md
@@ -144,7 +144,7 @@ These are the rules the skill file gives the agent and the code enforces. Togeth
 | Tool | What it does |
 |---|---|
 | `audio.py` | Voice clean-up chain, FFT denoise, typed compressor / limiter / gate, music bed with sidechain ducking, fades, 5.1 → stereo, track replacement, extraction (`-o out.wav`), `--audio-stream N` |
-| `sync.py` | Offset between two recordings by audio cross-correlation (1 ms, pure Python), clock-drift correction; aligned video or audio out |
+| `sync.py` | Offset between two recordings by audio cross-correlation (1 ms, pure Python), clock-drift correction; aligned video or audio out (audio-to-audio only — no lip-sync/face detection) |
 | `loudness.py` | Two-pass EBU R128 `loudnorm` to −14 LUFS / −1 dBTP or any target, video stream-copied; `--measure-only` |
 
 **Picture**

--- a/SKILL.md
+++ b/SKILL.md
@@ -176,7 +176,8 @@ Keep it to those five lines plus anything the user must decide. Attach the conta
 
 - Re-encoding an HDR (iPhone, HDR10) source through the SDR path: colours go flat. The scripts keep HDR; if you hand-write ffmpeg, do not tag BT.709 on BT.2020 pixels.
 - Lossless `-c copy` cuts on VFR or non-keyframe boundaries: the file "works" but starts on a frozen or wrong frame. `cut.py` re-encodes automatically when the snap exceeds 0.5 s; respect that.
-- A sync with `confidence` under 0.3, or an offset larger than 60 % of the analysis window: probably wrong; enlarge `--analyze-seconds` or find a clap.
+- A sync or multicam alignment with `confidence` under 0.3, or an offset larger than 60 % of the analysis window: probably wrong; enlarge `--analyze-seconds` or find a clap. `multicam.py` reports one `confidence` per camera — check all of them, not just that the command succeeded, before trusting the cut.
+- `sync.py`/`multicam.py` align audio tracks to each other, never lip sync (mouth movement vs. audio) — there is no face or mouth detection anywhere in this skill. A high confidence means the audio matched well, not that the picture looks right; if the user asks whether lip sync is correct, that needs a look at the actual video, not just the reported offset.
 - "Normalised" audio that still clips: check true peak, not just LUFS (`check.py` does both).
 - Normalising ambience or near-silence to a speech target: a clip measured at
   -40 LUFS or below is room tone, wind or nothing; raising it 25 dB raises the

--- a/scripts/multicam.py
+++ b/scripts/multicam.py
@@ -11,6 +11,14 @@ Switch list format: "START-END:CAM,START-END:CAM,..." with times on the
 reference timeline (seconds or mm:ss) and CAM = input index (0 = reference).
 Gaps fall back to camera 0.
 
+Each camera's `confidence` (in the report, and warned on stderr below 0.1)
+is how well its audio matched the reference's, not a guarantee the cut lands
+in sync: a source with no shared audio event (music-only vs. a silent room,
+or two rooms recording different conversations) can score low and still get
+an offset applied. Check it before trusting a low-confidence multicam edit.
+This aligns audio tracks to each other, the same as sync.py, and does not
+check lip sync (mouth movement vs. audio) at all -- see sync.py's docstring.
+
 Examples:
   python3 multicam.py camA.mp4 camB.mp4 --offsets-only                    # just report the offsets
   python3 multicam.py camA.mp4 camB.mp4 --switch "0-12:0,12-30:1,30-45:0" -o edit.mp4
@@ -108,6 +116,8 @@ def main() -> int:
         ratios.append(ratio)
         conf.append(score)
         info(f"{p}: offset {off:+.3f}s (confidence {score:.2f})" + (f", drift {(ratio - 1) * 1e6:+.0f} ppm" if args.fix_drift else ""))
+        if score < 0.1:
+            info(f"warning: {p} has low correlation confidence ({score:.2f}); check that it shares an audio event with the reference before trusting this offset")
 
     report = {"inputs": args.inputs, "offsets_seconds": [round(o, 4) for o in offsets],
               "confidence": [round(c, 3) for c in conf]}

--- a/scripts/sync.py
+++ b/scripts/sync.py
@@ -9,6 +9,14 @@ Python (coarse, 20 ms), then refined by direct correlation at 1 ms.
 Offset semantics: a positive offset means the SECOND input starts LATER
 than the reference, i.e. `second` must be shifted earlier by that amount.
 
+This aligns two AUDIO tracks to each other; it does not check or guarantee
+lip sync (mouth movement matching the audio). It assumes each recording's
+own audio is already correctly timed against its own picture, which holds
+for ordinary cameras and phones (same device, same clock) but not for a
+capture device with its own internal audio/video offset. There is no
+face or mouth detection anywhere in this codebase to verify that; the only
+way to confirm the final result actually looks in sync is to watch it.
+
 Examples:
   python3 sync.py camera.mp4 lavmic.wav                       # print offset only
   python3 sync.py camera.mp4 lavmic.wav --replace-audio -o synced.mp4

--- a/tests/test_all.py
+++ b/tests/test_all.py
@@ -593,6 +593,18 @@ class FFmpegSkillTests(unittest.TestCase):
         self.assertClose(probe(str(auto))["duration"], 12.0, 0.2)
         script("multicam.py", self.src, camB, "--switch", "0-3:5", expect_fail=True)
 
+    def test_multicam_warns_on_a_camera_with_no_shared_audio_event(self):
+        """A camera whose audio has nothing in common with the reference must not align silently."""
+        unrelated = OUT / "camC_unrelated.mp4"
+        # a flat-envelope tone: nothing for the envelope-based cross-correlation to lock onto,
+        # unlike the reference's gated tones -- unrelated in the way a different room's constant hum would be
+        sh("ffmpeg", "-y", "-hide_banner", "-loglevel", "error", "-f", "lavfi", "-i", "testsrc2=size=640x360:rate=30",
+           "-f", "lavfi", "-i", "sine=frequency=233:sample_rate=48000", "-t", "12", "-c:v", "libx264", "-preset", "veryfast", "-c:a", "aac", unrelated)
+        proc = script("multicam.py", self.src, unrelated, "--offsets-only", "--json")
+        data = json.loads(proc.stdout)
+        self.assertLess(data["confidence"][1], 0.1)
+        self.assertIn("low correlation confidence", proc.stderr)
+
     def test_verify_kit_runs_on_real_world_fixtures(self):
         folder = OUT / "vfx"
         folder.mkdir(exist_ok=True)


### PR DESCRIPTION
## Problem

X上のマルチカム同期精度に関するフィードバックへの回答を作る過程で、コードを確認したところ2つの問題が見つかりました。

1. **`multicam.py`に低信頼度の警告がない**: `sync.py`は相関の信頼度(`confidence`)が0.1未満のとき`"warning: low correlation confidence; check that both files contain the same audio event"`と警告しますが、同じ測定ロジックを流用している`multicam.py`には警告が一切ありませんでした。`multicam.py`は「レポートするだけ」の`sync.py`と違い、実際にその(信頼できない可能性のある)オフセットを適用してレンダリング済みの動画を書き出すため、影響がより大きいのに警告がより弱いという逆転状態でした。
2. **「音声同期」と「リップシンク」の区別がドキュメント化されていない**: `sync.py`/`multicam.py`はいずれも音声トラック同士の相互相関のみで、口の動きと音声が合っているかを検証する機能はコード上どこにも存在しません(顔・口の検出は一切なし)。「信頼度が高い」は「音声波形がよく一致した」という意味でしかなく、「最終的な映像でリップシンクが合っている」ことの保証にはなりません。この前提がどこにも明記されていませんでした。

## Changes

- `scripts/multicam.py`: カメラごとに`confidence < 0.1`のとき、`sync.py`と同じ閾値・同種の文言で警告を追加。docstringに、信頼度は「音声波形の一致度」であり「カットが同期している保証ではない」ことを明記。
- `scripts/sync.py`: docstringに「これは音声トラック同士の同期であり、リップシンク(口の動きと音声の一致)の検証ではない。顔・口検出は本コードベースに一切存在しない」ことを明記。
- `SKILL.md`: 既存の「confidence 0.3未満は疑うべき」というガイダンスに、`multicam.py`はカメラごとに信頼度が出るので全部確認すべきこと、および「音声同期≠リップシンク」の限界を追記。
- `README.md`: `sync.py`のツール一覧行に「audio-to-audio only — no lip-sync/face detection」を追記。
- `CHANGELOG.md`: Unreleasedセクションに追記。
- `tests/test_all.py`: 新規テスト — 基準カメラと共通の音声イベントを持たない(振幅一定のトーン)カメラを2台目に渡すと、`confidence`が0.1未満になり、実際に警告メッセージがstderrに出ることを確認。

CLIフラグ・契約(contract)・MCPスキーマに変更なし(警告追加とドキュメント追記のみ、既存の動作・出力構造は変わらず)。

## Tests

- `tests/test_all.py`: 73/73 PASS(新規1件含む、既存の`test_multicam_offsets_and_switch`・`test_sync_*`も引き続きPASS)
- `tests/test_contract.py`: 33/33 PASS(1 skip: real-device corpus未取得)

## Non-goals

顔・口の動きを画像認識でリップシンク検証する機能(コンピュータビジョン、外部依存が必要)は対象外。今回は「今の仕組みが実際に何をしているか/していないか」を偽りなく伝え、`multicam.py`の警告レベルを`sync.py`と揃える、という最小限の対応。

## Related

#25 (`fit.py --crop-x/--crop-y`)、#26 (`scenes.py --rank-by`) と同じ種類の問題(「本来ユーザー/エージェントが確認・判断すべきことを、ツールが暗黙に肩代わりして見せていた」)への対応です。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013tPrsGXLuaGU7t643QNUZs

---
_Generated by [Claude Code](https://claude.ai/code/session_013tPrsGXLuaGU7t643QNUZs)_