### PR TITLE
README: state this repo's role in the wider ecosystem, up front

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Changelog
 
+> `main` moves ahead of the last published npm/GitHub release; a dependent repo should pin a tagged version, not `main`. See README § Development, "Releasing".
+
 ## Unreleased — FFmpeg 8+ / Windows compatibility for caption and color
 
 - **`export.py --preset copy`.** Every existing preset re-encodes (even `prores`/`h265`, which

--- a/README.md
+++ b/README.md
@@ -31,8 +31,24 @@ If `ffmpeg` and `python3` are on your PATH, it works: offline, on footage you wo
 
 ---
 
+## Standalone, and in an ecosystem
+
+**Standalone**, this is a local FFmpeg engine: probe → edit → verify, `npx ffmpeg-skill` and nothing else. No API key, no account, no other repo required. Everything above and below this section describes that standalone tool, and none of it changes if you never read the rest of this one.
+
+**In [kajisho5](https://github.com/kajisho5)'s wider video-production ecosystem**, this repo is the *hands*: it cuts, measures and exports files, and reports back in structured JSON. It does not decide what to cut, whether a deliverable is approvable, or what makes a highlight interesting — those are a *brain*'s job, sitting in front of this engine, not inside it.
+
+| You want to... | Use |
+|---|---|
+| Cut / join / measure / export a file right now | **this repo** (`ffmpeg-skill`), standalone |
+| Decide cut points, approve a deliverable, plan a whole edit | [`video-production-agent`](https://github.com/kajisho5/video-production-agent) / [`AI-video-production-OS`](https://github.com/kajisho5/AI-video-production-OS) |
+| Build a typed editing graph across a workspace, without writing raw `ffmpeg` | [`video-editing-skill`](https://github.com/kajisho5/video-editing-skill) / [`audio-production-skill`](https://github.com/kajisho5/audio-production-skill) |
+
+Other repos in the ecosystem — [`media-analysis-skill`](https://github.com/kajisho5/media-analysis-skill), [`transcription-skill`](https://github.com/kajisho5/transcription-skill), [`subtitle-skill`](https://github.com/kajisho5/subtitle-skill), [`thumbnail-skill`](https://github.com/kajisho5/thumbnail-skill), [`color-grading-skill`](https://github.com/kajisho5/color-grading-skill), [`motion-graphics-skill`](https://github.com/kajisho5/motion-graphics-skill), [`qc-skill`](https://github.com/kajisho5/qc-skill) — read this repo's `contract --json`, its tools' `--json` output and `doctor`, the same way any agent framework would; this repo does not call into any of them. The dependency runs one way.
+
+---
+
 **Contents**
-[Why](#why) · [Quick start](#quick-start) · [How it works](#how-it-works) · [Design principles](#design-principles) · [Tools](#tools) · [Audio](#audio-is-a-first-class-input) · [Built for agents](#built-for-agents) · [FFmpeg compatibility](#ffmpeg-compatibility) · [Tested on real footage](#tested-on-real-footage) · [Install](#install) · [Requirements](#requirements) · [Development](#development) · [Docs](#docs)
+[Standalone, and in an ecosystem](#standalone-and-in-an-ecosystem) · [Why](#why) · [Quick start](#quick-start) · [How it works](#how-it-works) · [Design principles](#design-principles) · [Tools](#tools) · [Audio](#audio-is-a-first-class-input) · [Built for agents](#built-for-agents) · [FFmpeg compatibility](#ffmpeg-compatibility) · [Tested on real footage](#tested-on-real-footage) · [Install](#install) · [Requirements](#requirements) · [Development](#development) · [Docs](#docs)
 
 ---
 
@@ -310,6 +326,8 @@ node bin/install.js --dir /tmp/skills   # try the installer without touching ~/.
 ```
 
 CI (`.github/workflows/ci.yml`) runs on every pull request and on pushes to `main`, on Ubuntu (FFmpeg 6.1), macOS (Homebrew FFmpeg 8.x) and Windows (gyan.dev FFmpeg 9.x), and uploads each runner's FFmpeg listings as an artifact.
+
+**Releasing**: bump `version` in `package.json`, merge to `main`, then tag that commit (`git tag vX.Y.Z && git push origin vX.Y.Z`) and cut a GitHub Release from the tag, with the matching `CHANGELOG.md` section as its body. A repo that depends on this one (an editing skill, an agent) should pin an `ffmpeg-skill` version by tag or npm version, not by tracking `main` — `main` can be ahead of the last published npm version.
 
 ## Docs
 


### PR DESCRIPTION
## Problem

外部評価(Grok)で指摘された通り、READMEの先頭は今も「単体製品」の見え方のままで、`kajisho5`のエコシステム(`video-production-agent`, `AI-video-production-OS`, `video-editing-skill`ほか)における位置づけは`Design principles`の4番目に一文だけ埋もれていました。「切るのはここ、決めるのは向こう」が15秒で分かる場所にありませんでした。

## Changes

- `README.md`: 導入文とContentsナビの間に新セクション`## Standalone, and in an ecosystem`を追加(25〜40行程度)
  - **Standalone**: `npx ffmpeg-skill`だけで probe→edit→verify が完結すること
  - **エコシステム内**: このリポは「手」であり、何を切るか・納品可否・ハイライトの面白さといった「判断」は一切しないこと
  - 3行の使い分け表(ファイル操作はこのリポ / カット点・承認・計画はagent側 / typedな編集グラフはvideo-editing-skill側)
  - 実在する全兄弟リポへのリンク(`video-production-agent`, `AI-video-production-OS`, `video-editing-skill`, `audio-production-skill`, `media-analysis-skill`, `transcription-skill`, `subtitle-skill`, `thumbnail-skill`, `color-grading-skill`, `motion-graphics-skill`, `qc-skill`)
  - 「他リポはこちらの`contract --json`/`--json`出力/`doctor`を読む。こちらは他リポをimportしない」という一方向の依存関係を明記
- `README.md`(Development節)・`CHANGELOG.md`(先頭): リリース手順(`package.json`の版をtag化しGitHub Releaseにする)を明文化。依存側は`main`ではなくtag/npm版をピンすべき、と明記。**バージョン自体のbumpはこのコミットに含みません**。

## Non-goals (今回やらないこと)

- 他リポジトリを開いて編集すること(リンクを書くだけ)
- `package.json`のversion bump、実際のtag切り・Release作成そのもの(このPRはドキュメントのみ)
- 新規`scripts/*.py`の追加、既存21ツールの機能変更

## Tests

コード変更なし(README/CHANGELOGのみ)。念のため`SKILL.md`/`README.md`の内容を検証する既存テスト(`test_visual_verification_metadata`)が引き続き通ることを確認済み。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013tPrsGXLuaGU7t643QNUZs

---
_Generated by [Claude Code](https://claude.ai/code/session_013tPrsGXLuaGU7t643QNUZs)_