### PR TITLE
join.py: fix filtergraph index for the second+ audio-less clip

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,21 @@
 
 > `main` moves ahead of the last published npm/GitHub release; a dependent repo should pin a tagged version, not `main`. See README § Development, "Releasing".
 
+## Unreleased
+
+- **`join.py`: joining two or more audio-less clips together failed.** Each clip missing an audio
+  track gets a synthetic silent input (`-f lavfi -i anullsrc=...`) appended to the ffmpeg command;
+  the filtergraph index for that input was computed as `n + len(extra_inputs)`, but
+  `extra_inputs` is a flat argv list (six tokens per synthetic input: `-f`, `lavfi`, `-t`,
+  duration, `-i`, `anullsrc=...`), not a count of inputs added so far. With exactly one no-audio
+  clip the two counts happen to coincide (`n + 0`); from the second no-audio clip onward the
+  computed index overshoots the real one by a multiple of 6, and ffmpeg refused the whole command
+  with "Invalid file index" naming an input far past the actual count. Found joining five real,
+  audio-less camera samples (a genuine multi-camera source with no audio channel is not an edge
+  case in real footage). Fixed by tracking the number of synthetic inputs added directly, instead
+  of inferring it from the argv list's length. No change to the single-no-audio-clip path, which
+  was already correct.
+
 ## 0.10.0 — 2026-09-06 — FFmpeg 8+/Windows compatibility, per-tool doctor/contract usability, provenance and honesty fixes
 
 - **`doctor --json`: per-tool `usable`.** `doctor` reported capability-level `available`/`missing`/`unknown`, but a caller had to cross-reference each tool's own required capabilities by hand to answer "can I run `caption.py` on this machine today" -- a plain Homebrew `ffmpeg` on macOS is `ok` overall (nothing *required by every tool* is missing) while `caption.py` specifically cannot run at all. The new `tools` field folds the same per-capability state into `{"<tool>": {"usable": "yes"|"no"|"unknown", "missing": [...], "fix": "one-line remedy", "unknown": [...]}}` per tool, following the same "unknown is not missing" rule doctor already uses. Additive; every existing `doctor` key is unchanged.

--- a/scripts/join.py
+++ b/scripts/join.py
@@ -141,15 +141,22 @@ def main() -> int:
     n = len(args.inputs)
     for i, (p, m) in enumerate(zip(args.inputs, metas)):
         cmd += ["-i", p]
-    # silent audio for clips without an audio track
+    # silent audio for clips without an audio track. `idx` is this ffmpeg input's position, i.e. n +
+    # how many synthetic inputs were already added -- not len(extra_inputs), which counts the six
+    # argv tokens ("-f", "lavfi", "-t", duration, "-i", "anullsrc=...") each synthetic input adds, not
+    # the input itself. With one no-audio clip both counts coincide (n + 0); from the second no-audio
+    # clip onward they diverge, and the previous `n + len(extra_inputs)` named a nonexistent, far-out-of-
+    # range ffmpeg input index -- found via a real multi-camera join where every clip lacked audio.
     audio_src: List[str] = []
+    added = 0
     for i, m in enumerate(metas):
         if m.get("audio"):
             audio_src.append(f"{i}:a:0")
         else:
-            idx = n + len(extra_inputs)
+            idx = n + added
             extra_inputs += ["-f", "lavfi", "-t", f"{durs[i]:.3f}", "-i", "anullsrc=r=48000:cl=stereo"]
             audio_src.append(f"{idx}:a:0")
+            added += 1
     cmd += extra_inputs
 
     if args.fit == "crop":

--- a/tests/test_all.py
+++ b/tests/test_all.py
@@ -536,6 +536,30 @@ class FFmpegSkillTests(unittest.TestCase):
         self.assertClose(probe(str(out2))["duration"], 16.0, 0.3)
         script("join.py", self.src, expect_fail=True)
 
+    def test_join_two_or_more_audio_less_clips(self):
+        """Every no-audio clip gets a synthetic silent audio track added as an extra ffmpeg input (join.py
+        builds this itself, not this test's fixtures) -- `idx` must be this ffmpeg input's actual position
+        (n + how many synthetic inputs were already added), not `n + len(extra_inputs)` (the six argv tokens
+        each synthetic input contributes, not a count of inputs). With exactly one no-audio clip both counts
+        happen to agree; a real multi-camera join where every clip lacked audio is what caught the divergence
+        starting from the second one -- ffmpeg refused with "Invalid file index" naming an input far past the
+        real count, since the miscomputed index grew by 6 (not 1) per extra no-audio clip."""
+        silent_a = OUT / "silent_a.mp4"
+        silent_b = OUT / "silent_b.mp4"
+        silent_c = OUT / "silent_c.mp4"
+        for out, size in ((silent_a, "640x360"), (silent_b, "480x270"), (silent_c, "960x540")):
+            sh("ffmpeg", "-y", "-hide_banner", "-loglevel", "error", "-f", "lavfi", "-i", f"testsrc2=size={size}:rate=25", "-t", "3", "-c:v", "libx264", "-preset", "veryfast", out)
+        out = OUT / "joined_all_silent.mp4"
+        script("join.py", silent_a, silent_b, silent_c, "--transition", "none", "--preset", "veryfast", "-o", out)
+        m = probe(str(out))
+        self.assertClose(m["duration"], 9.0, 0.3)
+        self.assertEqual(m["audio"]["channels"], 2, "every clip's missing track became silent stereo, not a dropped audio stream")
+        # mixed: audio-bearing clip first, then two without -- exercises the same off-by-more-than-one index
+        # for the second and third synthetic input regardless of which position the real audio clip sits in
+        out2 = OUT / "joined_mixed_silent.mp4"
+        script("join.py", self.src, silent_a, silent_b, "--transition", "none", "--preset", "veryfast", "-o", out2)
+        self.assertClose(probe(str(out2))["duration"], 12 + 3 + 3, 0.3)
+
     def test_dry_run_and_json_on_every_script(self):
         cases = [
             ("cut.py", [self.src, "--start", "1", "--end", "3"]),


### PR DESCRIPTION
## Summary

Found via real-world validation (five genuine, audio-less camera clips supplied by the user, not synthetic test fixtures) of `video-production-agent`'s full pipeline: concatenating multiple audio-less clips crashed ffmpeg with `Invalid file index 11 in filtergraph description`.

**Root cause**: for each clip missing an audio track, `join.py` appends a synthetic silent-audio ffmpeg input (`-f lavfi -i anullsrc=...`) and computes its filtergraph index as `idx = n + len(extra_inputs)`. `extra_inputs` is a flat argv list — six tokens per synthetic input (`-f`, `lavfi`, `-t`, duration, `-i`, `anullsrc=...`) — not a count of inputs added so far. The two values only coincide for the *first* audio-less clip (`n + 0`); starting with the second one, the computed index overshoots the real ffmpeg input position by a multiple of 6, so the filtergraph references an input that doesn't exist.

**Fix**: track the count of synthetic inputs added directly (`added`), instead of inferring it from `len(extra_inputs)`.

## Verification (real commands)

- Reproduced against the real five-clip source directly with `scripts/join.py`, confirmed the exact "Invalid file index 11" failure before the fix, and a correct 82.05s / 1920x1080 / 29.97fps / 48kHz-stereo-silent output after it.
- New regression test (`test_join_two_or_more_audio_less_clips`): joins three audio-less clips, and a mixed case (one audio-bearing + two without) — both scenarios the existing single-no-audio-clip test never exercised.
- Full suite: `tests/test_all.py` **72 passed, 1 skipped** (up from 71+1, +1 new test); `tests/test_contract.py` **32 passed, 1 skipped**. Zero regressions.

## Test plan
- [x] `python3 -m pytest tests/test_all.py` (72 passed, 1 skipped)
- [x] `python3 -m pytest tests/test_contract.py` (32 passed, 1 skipped)
- [x] Manual repro against the real 5-clip source, before and after the fix

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TdkXAJ5yMz9qKodK2f5S7i

---
_Generated by [Claude Code](https://claude.ai/code/session_01TdkXAJ5yMz9qKodK2f5S7i)_