### PR TITLE
Add ci-pipeline-synthesizer as a project-local dev tool (not shipped)

### DIFF
--- a/.claude/skills/ci-pipeline-synthesizer/SKILL.md
+++ b/.claude/skills/ci-pipeline-synthesizer/SKILL.md
@@ -1,0 +1,128 @@
+---
+name: ci-pipeline-synthesizer
+description: Generate GitHub Actions CI/CD pipeline configurations for automated building and testing of library and package projects. Use when creating or updating CI workflows for npm packages, Python packages, Go modules, Rust crates, or other library projects that need automated build and test pipelines. Includes templates for common package ecosystems with best practices for dependency caching, matrix testing, and artifact publishing.
+---
+
+# CI Pipeline Synthesizer
+
+## Overview
+
+Generate production-ready GitHub Actions workflow files for library and package projects with automated build and test stages, dependency caching, and multi-version testing matrices.
+
+## Workflow
+
+### 1. Identify Project Type
+
+Determine the package ecosystem by examining project files:
+- **Node.js/npm**: `package.json` present
+- **Python**: `setup.py`, `pyproject.toml`, or `requirements.txt` present
+- **Go**: `go.mod` present
+- **Rust**: `Cargo.toml` present
+
+### 2. Select Template
+
+Use the appropriate template from `assets/` based on project type:
+- `github-actions-nodejs.yml` - Node.js/npm packages
+- `github-actions-python.yml` - Python packages
+- `github-actions-go.yml` - Go modules
+- `github-actions-rust.yml` - Rust crates
+
+### 3. Customize Configuration
+
+Adapt the template to project-specific needs:
+
+**Test commands**: Update test scripts to match project conventions
+- Node.js: `npm test`, `npm run test:coverage`
+- Python: `pytest`, `python -m unittest`
+- Go: `go test ./...`
+- Rust: `cargo test`
+
+**Build commands**: Adjust build steps if needed
+- Node.js: `npm run build` (if build step exists)
+- Python: `python -m build`
+- Go: `go build`
+- Rust: `cargo build --release`
+
+**Version matrix**: Modify tested versions based on support policy
+- Node.js: LTS versions (16.x, 18.x, 20.x)
+- Python: Active versions (3.9, 3.10, 3.11, 3.12)
+- Go: Recent versions (1.21, 1.22)
+- Rust: stable, beta (optional)
+
+**Trigger conditions**: Adjust when pipeline runs
+- Default: Push to main/master, all pull requests
+- Custom: Specific branches, paths, or schedules
+
+### 4. Place Workflow File
+
+Create the workflow file at `.github/workflows/ci.yml` in the project root. If `.github/workflows/` doesn't exist, create the directory structure first.
+
+### 5. Verify Configuration
+
+Check that the generated workflow:
+- Uses appropriate actions versions (e.g., `actions/checkout@v4`, `actions/setup-node@v4`)
+- Includes dependency caching for faster builds
+- Runs on appropriate triggers (push, pull_request)
+- Tests against relevant version matrices
+- Has clear job and step names
+
+## Template Features
+
+All templates include:
+- **Dependency caching**: Speeds up builds by caching package managers
+- **Matrix testing**: Tests across multiple language/runtime versions
+- **Parallel execution**: Runs tests for different versions concurrently
+- **Clear naming**: Descriptive job and step names for easy debugging
+- **Best practices**: Uses recommended actions and configurations
+
+## Customization Examples
+
+**Add code coverage reporting**:
+```yaml
+- name: Upload coverage to Codecov
+  uses: codecov/codecov-action@v3
+  with:
+    file: ./coverage.xml
+```
+
+**Add linting step**:
+```yaml
+- name: Run linter
+  run: npm run lint  # or: pylint, golangci-lint, cargo clippy
+```
+
+**Restrict to specific branches**:
+```yaml
+on:
+  push:
+    branches: [main, develop]
+  pull_request:
+    branches: [main]
+```
+
+**Add scheduled runs**:
+```yaml
+on:
+  schedule:
+    - cron: '0 0 * * 0'  # Weekly on Sunday
+```
+
+## Tips
+
+- Start with the template and customize incrementally
+- Test the workflow by creating a pull request or pushing to a test branch
+- Use `actions/cache` for dependencies to reduce build times
+- Keep matrix versions current with language support policies
+- Add status badges to README.md: `![CI](https://github.com/user/repo/workflows/CI/badge.svg)`
+
+## Note for this repository (ffmpeg-skill)
+
+This skill's generic templates assume ordinary language-toolchain dependencies
+(pip/npm/go/cargo). They do NOT model this repo's actual CI needs — installing
+a real `ffmpeg` binary per OS (apt/brew ffmpeg-full/choco), capturing its
+`-filters`/`-encoders`/`-bsfs` listings as an artifact, or the `skipIf`-based
+Windows test coverage in `tests/test_contract.py` — all of which
+`.github/workflows/ci.yml` already handles and this skill's templates would
+not reproduce. Treat this as reference/scaffolding for a plain Python/Node/Go/
+Rust package elsewhere, not a drop-in replacement for this repo's own
+workflow.

--- a/.claude/skills/ci-pipeline-synthesizer/assets/github-actions-go.yml
+++ b/.claude/skills/ci-pipeline-synthesizer/assets/github-actions-go.yml
@@ -1,0 +1,34 @@
+name: CI
+
+on:
+  push:
+    branches: [main, master]
+  pull_request:
+    branches: [main, master]
+
+jobs:
+  build-and-test:
+    runs-on: ubuntu-latest
+
+    strategy:
+      matrix:
+        go-version: ['1.21', '1.22']
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Setup Go ${{ matrix.go-version }}
+        uses: actions/setup-go@v5
+        with:
+          go-version: ${{ matrix.go-version }}
+          cache: true
+
+      - name: Download dependencies
+        run: go mod download
+
+      - name: Run tests
+        run: go test -v ./...
+
+      - name: Build package
+        run: go build -v ./...

--- a/.claude/skills/ci-pipeline-synthesizer/assets/github-actions-nodejs.yml
+++ b/.claude/skills/ci-pipeline-synthesizer/assets/github-actions-nodejs.yml
@@ -1,0 +1,34 @@
+name: CI
+
+on:
+  push:
+    branches: [main, master]
+  pull_request:
+    branches: [main, master]
+
+jobs:
+  build-and-test:
+    runs-on: ubuntu-latest
+
+    strategy:
+      matrix:
+        node-version: [16.x, 18.x, 20.x]
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js ${{ matrix.node-version }}
+        uses: actions/setup-node@v4
+        with:
+          node-version: ${{ matrix.node-version }}
+          cache: 'npm'
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Run tests
+        run: npm test
+
+      - name: Build package
+        run: npm run build --if-present

--- a/.claude/skills/ci-pipeline-synthesizer/assets/github-actions-python.yml
+++ b/.claude/skills/ci-pipeline-synthesizer/assets/github-actions-python.yml
@@ -1,0 +1,36 @@
+name: CI
+
+on:
+  push:
+    branches: [main, master]
+  pull_request:
+    branches: [main, master]
+
+jobs:
+  build-and-test:
+    runs-on: ubuntu-latest
+
+    strategy:
+      matrix:
+        python-version: ['3.9', '3.10', '3.11', '3.12']
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Setup Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v5
+        with:
+          python-version: ${{ matrix.python-version }}
+          cache: 'pip'
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -e .[dev]
+
+      - name: Run tests
+        run: pytest
+
+      - name: Build package
+        run: python -m build

--- a/.claude/skills/ci-pipeline-synthesizer/assets/github-actions-rust.yml
+++ b/.claude/skills/ci-pipeline-synthesizer/assets/github-actions-rust.yml
@@ -1,0 +1,48 @@
+name: CI
+
+on:
+  push:
+    branches: [main, master]
+  pull_request:
+    branches: [main, master]
+
+jobs:
+  build-and-test:
+    runs-on: ubuntu-latest
+
+    strategy:
+      matrix:
+        rust-version: [stable, beta]
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Setup Rust ${{ matrix.rust-version }}
+        uses: dtolnay/rust-toolchain@master
+        with:
+          toolchain: ${{ matrix.rust-version }}
+
+      - name: Cache cargo registry
+        uses: actions/cache@v4
+        with:
+          path: ~/.cargo/registry
+          key: ${{ runner.os }}-cargo-registry-${{ hashFiles('**/Cargo.lock') }}
+
+      - name: Cache cargo index
+        uses: actions/cache@v4
+        with:
+          path: ~/.cargo/git
+          key: ${{ runner.os }}-cargo-index-${{ hashFiles('**/Cargo.lock') }}
+
+      - name: Cache cargo build
+        uses: actions/cache@v4
+        with:
+          path: target
+          key: ${{ runner.os }}-cargo-build-target-${{ hashFiles('**/Cargo.lock') }}
+
+      - name: Run tests
+        run: cargo test --verbose
+
+      - name: Build package
+        run: cargo build --release --verbose


### PR DESCRIPTION
## Summary

Adds the `ci-pipeline-synthesizer` skill from [ArabelaTso/Skills-4-SE](https://github.com/ArabelaTso/Skills-4-SE) (MIT-licensed) under `.claude/skills/` — a Claude Code dev-tooling addition, not a change to the published package.

- **Not shipped**: `.claude/` is not in `package.json`'s `"files"` list, so this never reaches an end user running `npx ffmpeg-skill`. Verified with `npm publish --dry-run`.
- **Honest limitation noted inline**: added a paragraph to the copied `SKILL.md` stating this skill's generic npm/Python/Go/Rust CI templates do not model this repo's actual CI needs (real per-OS `ffmpeg` install, `-filters`/`-encoders`/`-bsfs` listing capture, the `skipIf`-based Windows contract-test coverage from #40) — it's reference/scaffolding for a different, simpler project, not a replacement for `.github/workflows/ci.yml`.

## Why
Requested as a general-purpose dev-tool addition after surveying available skill catalogs for ones that could help with this repo's engineering workflow (CI, testing, release process).

## Test plan
- [x] `npm publish --dry-run` — confirms `.claude/` is not packaged
- No code changes; nothing else to test

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013tPrsGXLuaGU7t643QNUZs

---
_Generated by [Claude Code](https://claude.ai/code/session_013tPrsGXLuaGU7t643QNUZs)_