### PR TITLE
tests: cover overlay.py --image on an audio-less video

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@
 
 ## Unreleased
 
+- **Tests: `overlay.py --image` on an audio-less video is now covered.** Every existing overlay test used a
+  source with audio; investigating a downstream report of `overlay.py` "hanging" on audio-less input (the
+  historical 0.9.x defect this tool's own `-t <duration>` fix, added in 0.10.0, was meant to close) found the
+  fix already works — the run had just been mistaken for a hang under a too-short timeout while it was still
+  transcoding a 1080p60 frame with a fade filter. No code change; `test_overlay_on_audio_less_video_terminates`
+  closes the coverage gap so this defect class can't silently regress.
 - **`join.py`: joining two or more audio-less clips together failed.** Each clip missing an audio
   track gets a synthetic silent input (`-f lavfi -i anullsrc=...`) appended to the ffmpeg command;
   the filtergraph index for that input was computed as `n + len(extra_inputs)`, but

--- a/tests/test_all.py
+++ b/tests/test_all.py
@@ -1306,6 +1306,22 @@ class FFmpegSkillTests(unittest.TestCase):
         self.assertIn("-t", data["commands"][0])
         self.assertClose(data["probe"]["duration"], 12.0, 0.15)
 
+    def test_overlay_on_audio_less_video_terminates(self):
+        """Every other overlay test uses self.src, which has audio. Cover the audio-less case too:
+        overlay is documented elsewhere as risky on inputs with no audio stream to help -shortest
+        bound the looped-image (-loop 1) input, so pin down that it completes and the output duration
+        matches the source exactly (the explicit -t, not -shortest, is what actually bounds it)."""
+        noaudio = OUT / "overlay_noaudio_source.mp4"
+        sh("ffmpeg", "-y", "-hide_banner", "-loglevel", "error", "-i", self.src, "-an", "-c:v", "copy", noaudio)
+        self.assertIsNone(probe(str(noaudio)).get("audio"))
+        out = OUT / "overlay_noaudio.mp4"
+        proc = subprocess.run(
+            [sys.executable, str(SCRIPTS / "overlay.py"), str(noaudio), "--image", str(self.logo),
+             "--position", "bottom-right", "--start", "1", "--end", "5", "--fade", "0.3", "-o", str(out)],
+            stdout=subprocess.PIPE, stderr=subprocess.PIPE, text=True, encoding="utf-8", errors="replace", timeout=60)
+        self.assertEqual(proc.returncode, 0, f"STDOUT:\n{proc.stdout}\nSTDERR:\n{proc.stderr}")
+        self.assertClose(probe(str(out))["duration"], probe(str(noaudio))["duration"], 0.15)
+
     def test_help_survives_a_legacy_console_encoding(self):
         """--help contains non-ASCII (Japanese example, arrows); a cp1252 console must not raise UnicodeEncodeError."""
         env = dict(os.environ, PYTHONIOENCODING="cp1252")


### PR DESCRIPTION
## Summary
- Every existing `overlay.py` test used a source with audio, so the historical 0.9.x "`-loop 1` image + `-shortest` never terminates without audio" defect class had no regression coverage for the fix (an explicit `-t <duration>`) already shipped in 0.10.0.
- Investigating a downstream report of a hang on real, audio-less camera footage found the fix already works correctly: a 41s run was mistaken for a hang under a 40s timeout while ffmpeg was still transcoding a 1080p60 frame with a fade filter, not stuck.
- No code change — just the missing test, `test_overlay_on_audio_less_video_terminates`, plus a CHANGELOG note recording the investigation so this defect class can't silently regress unnoticed.

## Test plan
- [x] `pytest tests/test_all.py -k overlay -v` — 4 passed (all overlay tests, including the new one)
- [x] `pytest tests/test_all.py` — full suite: 75 passed, 1 skipped
- [x] Verified the new test also passes against the pre-existing (unmodified) `overlay.py`, confirming no hang exists today

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TdkXAJ5yMz9qKodK2f5S7i

---
_Generated by [Claude Code](https://claude.ai/code/session_01TdkXAJ5yMz9qKodK2f5S7i)_