### PR TITLE
test: exercise non-ASCII filenames end-to-end through probe/cut argv

### DIFF
--- a/tests/test_contract.py
+++ b/tests/test_contract.py
@@ -655,6 +655,38 @@ class ContractTests(unittest.TestCase):
         self.assertEqual(proc.returncode, 127)
         self.assertEqual(json.loads(proc.stdout)["error"]["kind"], "missing_tool")
 
+    def test_probe_and_cut_on_a_non_ascii_filename(self):
+        """A file whose *name itself* (not just a path referenced inside a filter-graph string,
+        which test_filter_paths_with_drive_colon_spaces_and_unicode already covers) contains CJK
+        and accented characters must round-trip correctly as -i/output argv through subprocess.
+
+        Python 3.9 (this repo's CI-pinned version) uses CreateProcessW for subprocess argv on
+        Windows, and the filesystem encoding is UTF-8 on macOS/Linux, so this is expected to work
+        on all three OSes -- but this sandbox can only actually execute on Linux. This test is
+        the mechanism by which the claim gets verified on Windows and macOS too, once this runs
+        through the existing CI matrix (see .github/workflows/ci.yml).
+        """
+        src = self.work / "日本語_ünïcödé.mp4"
+        shutil.copyfile(self.src, src)
+        # read tool: probe.py against the non-ASCII input path
+        meta = json.loads(tool("probe", src, "--json").stdout)
+        self.assertAlmostEqual(meta["duration"], 6.0, delta=0.3)
+        self.assertEqual(meta["video"]["width"], 640)
+        # write tool: cut.py, non-ASCII input -> plain-ASCII output
+        out_ascii = self.out("nonascii_cut.mp4")
+        doc = json.loads(tool("cut", src, "--start", "1", "--end", "3", "-o", out_ascii, "--json").stdout)
+        self.assertEqual(doc["status"], "completed")
+        self.assertAlmostEqual(doc["probe"]["duration"], 2.0, delta=0.6)
+        reprobed = json.loads(tool("probe", out_ascii, "--json").stdout)
+        self.assertAlmostEqual(reprobed["duration"], 2.0, delta=0.6)
+        # and the other direction: plain-ASCII input -> non-ASCII output path
+        out_unicode = self.work / "出力_prüfung.mp4"
+        doc2 = json.loads(tool("cut", self.src, "--start", "0", "--end", "2", "-o", out_unicode, "--json").stdout)
+        self.assertEqual(doc2["status"], "completed")
+        self.assertTrue(out_unicode.exists())
+        reprobed2 = json.loads(tool("probe", out_unicode, "--json").stdout)
+        self.assertAlmostEqual(reprobed2["duration"], 2.0, delta=0.6)
+
     # ------------------------------------------------------------------ fail loudly
     def _fails(self, name, *args, kind=None, code=None):
         proc = tool(name, *args, "--json", check=False)


### PR DESCRIPTION
Closes #67

## Summary
- Existing `test_filter_paths_with_drive_colon_spaces_and_unicode` (in `tests/test_all.py`) already covers Unicode paths as *filter-graph string values* (`escape_filter_path`, used by `subtitles=`, `lut3d=file=`, `fontfile=`, `fontsdir=`).
- Nothing previously tested a non-ASCII (CJK/accented) filename as the actual `-i`/output argument passed through `subprocess` argv.
- Adds `test_probe_and_cut_on_a_non_ascii_filename` to `tests/test_contract.py`: copies the existing `self.src` fixture to `日本語_ünïcödé.mp4`, runs `probe.py` (read tool) against it and asserts sane duration/width, then runs `cut.py` (write tool) both with a non-ASCII input → ASCII output and an ASCII input → non-ASCII output (`出力_prüfung.mp4`), re-probing each result to confirm correct output duration.
- Reuses the existing small synthetic fixture; no new media assets added, consistent with the issue's "don't add fixtures indiscriminately" guidance.
- No production code changes — this closes a test-coverage gap, not a known bug.

## Honesty note on platform coverage
This sandbox only runs Linux, so I can only directly verify UTF-8 filesystem-encoded argv here. The docstring says so explicitly rather than claiming Windows/macOS coverage — the real value of adding this test is that it will actually execute on Windows and macOS once this repo's existing 3-OS CI matrix runs it, proving (or disproving) the `CreateProcessW` / UTF-8 filesystem-encoding assumption the issue raises.

## Test plan
- [x] `python3 tests/test_contract.py ContractTests.test_probe_and_cut_on_a_non_ascii_filename -v` — passes on Linux
- [x] Full `python3 tests/test_contract.py` — 49 tests, all pass (1 unrelated skip: real-device corpus not downloaded)
- No real bug found — the new test passes cleanly on Linux; this is pure coverage addition.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013tPrsGXLuaGU7t643QNUZs

---
_Generated by [Claude Code](https://claude.ai/code/session_013tPrsGXLuaGU7t643QNUZs)_