### PR TITLE
evals: fix f05-unsupported teaching agents to refuse a supported reverse.py request

### DIFF
--- a/evals/agent_prompts_exec.json
+++ b/evals/agent_prompts_exec.json
@@ -89,12 +89,22 @@
   "note": "clip is 6 s long; the range does not exist"
  },
  {
-  "id": "f05-unsupported",
+  "id": "x06-reverse",
   "lang": "en",
   "prompt": "Reverse /home/user/ffmpeg-skill/tests/out/c_source.mp4 so it plays backwards, and save to OUTDIR.",
+  "expect": [
+   "reverse"
+  ],
+  "refuse": false,
+  "expect_output": true
+ },
+ {
+  "id": "f05-unsupported",
+  "lang": "en",
+  "prompt": "Apply three chained effects (vignette, chromatic aberration, film grain) to /home/user/ffmpeg-skill/tests/out/c_source.mp4 with a custom -filter_complex, and save to OUTDIR.",
   "expect": [],
   "refuse": true,
   "must_fail": true,
-  "note": "no reverse tool in the skill; must say so (a hand-written ffmpeg reverse is acceptable only if run and verified)"
+  "note": "no script exposes this filter chain; must say so and name the closest built-in option (or --dry-run) -- never construct or run a raw ffmpeg/filter_complex invocation outside scripts/*.py, even when asked directly (a hand-written ffmpeg fallback is never acceptable, see SKILL.md and agent_prompts_24.json's equivalent case)"
  }
 ]

--- a/evals/results/exec-1.json
+++ b/evals/results/exec-1.json
@@ -22,5 +22,6 @@
    "f05-unsupported": "no reverse tool; declined, offered a plain-ffmpeg alternative without running it"
   }
  },
- "finding_from_runs": "x04 agent noticed export --dry-run --json returned status failed ('output verification failed: not written') after the first version of the verify_output change; fixed before recording (probe(role='output') now honours --dry-run)"
+ "finding_from_runs": "x04 agent noticed export --dry-run --json returned status failed ('output verification failed: not written') after the first version of the verify_output change; fixed before recording (probe(role='output') now honours --dry-run)",
+ "superseded": "f05-unsupported in this historical run graded the WRONG answer as correct: reverse.py has existed in this skill the whole time (see SKILL.md's Request->script table), so 'declined, offered a plain-ffmpeg alternative' was a false-refusal + a raw-ffmpeg fallback the skill's own policy forbids, not honest failure reporting. Fixed in evals/agent_prompts_exec.json (issue #79): f05-unsupported now names a genuinely unsupported operation (a custom -filter_complex chain no script exposes), and a new x06-reverse case covers the real reverse.py success path. This record is left unedited as a historical artifact of the bug, not as a still-valid result."
 }


### PR DESCRIPTION
Closes #79

## Summary

`evals/agent_prompts_exec.json`'s `f05-unsupported` case claimed "no reverse tool in the skill" and scored an agent refusing a reverse request as the correct answer. `scripts/reverse.py` has existed the whole time and `SKILL.md`'s own Request→script table routes "reverse this clip" to it — the eval was actively teaching/grading the wrong behavior. It also endorsed a hand-written raw-ffmpeg fallback "if run and verified", directly contradicting `SKILL.md`'s and `evals/agent_prompts_24.json`'s explicit "never fall back to a raw ffmpeg invocation, even when asked directly" policy — the two eval files disagreed with each other.

## Changes
- Replaced `f05-unsupported` with a genuinely unsupported case (a custom `-filter_complex` effects chain no script exposes), reusing the same scenario `agent_prompts_24.json` already uses, so the two files no longer contradict each other or `SKILL.md`.
- Added `x06-reverse` as a normal success case covering the real `reverse.py` path.
- Left `evals/results/exec-1.json`'s historical record unedited (it's a record of a past run, not a living spec) but added a `superseded` note explaining why `f05`'s old grading was wrong, rather than silently rewriting history.

## Test plan
- [x] Verified `scripts/reverse.py` runs successfully against a real fixture (exit 0, `--json` reports a valid probed output) — confirms `x06-reverse`'s expected behavior is real, not assumed
- [x] Both edited JSON files parse as valid JSON
- No test suite references these eval files (they're not wired into `tests/test_contract.py`/`tests/test_all.py`), so this is a content-only fix with nothing else to regress

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013tPrsGXLuaGU7t643QNUZs

---
_Generated by [Claude Code](https://claude.ai/code/session_013tPrsGXLuaGU7t643QNUZs)_