### PR TITLE
SKILL.md: complete the dry-run exception list in step 3, fix stale retag description

### DIFF
--- a/SKILL.md
+++ b/SKILL.md
@@ -30,11 +30,17 @@ Scripts live in `scripts/` next to this file; run them with `python3 <skill-dir>
 3. **Plan with `--dry-run --json`, then execute.** Every script accepts
    `--dry-run` (prints the ffmpeg commands that would run) and `--json`
    (structured result: output path, probe of the output, commands run). For
-   writing tools this means nothing is written; a few tools (`sync`,
-   `multicam`, `scenes`, `report`) still run ffmpeg/ffprobe to measure or
-   analyse under `--dry-run` — see `contract --json`'s `dry_run` field per
-   tool. Use them to confirm a plan before long encodes and to report exact
-   facts. `--fast` gives a quick preview-quality render (x264 veryfast), `--progress`
+   writing tools this means nothing is written; `probe`/`check` still run
+   ffprobe/loudness-measurement passes (they're read-only, so `--dry-run`
+   changes nothing for `probe`, and only skips the loudness pass for
+   `check`), `sync`/`multicam`/`scenes`/`report` still run ffmpeg/ffprobe to
+   measure or analyse, and `verify` accepts the flag but ignores it entirely
+   (its steps run regardless) — see `contract --json`'s `dry_run` field per
+   tool for exact semantics. Trust `--json`, not a dry-run's human-readable
+   summary line, for any number after the plan (dimensions in that line can
+   be a placeholder, not a computed preview — see `docs/contract.md`). Use
+   them to confirm a plan before long encodes and to report exact facts.
+   `--fast` gives a quick preview-quality render (x264 veryfast), `--progress`
    prints percent and ETA on stderr for long encodes.
 4. **Chain operations in a sensible order.** Colour (HDR→SDR / LUT) → cut →
    join → silence → fit → caption/overlay → sync → audio → loudness → export.
@@ -163,7 +169,7 @@ If a request needs an FFmpeg feature none of the 28 scripts expose, say so and n
 | "show me progress", "quick preview first" | any encoding script with `--progress` and/or `--fast` |
 | "the colours look washed out / it's an iPhone HDR video" | `color.py input.mov --to-sdr` (probe shows `hdr: true`) |
 | "apply this LUT", "convert the S-Log / V-Log footage" | `color.py input.mp4 --lut grade.cube [--lut-strength 0.7]` |
-| "the colours are tagged wrong" | `color.py input.mp4 --retag bt709` (no re-encode) |
+| "the colours are tagged wrong" | `color.py input.mp4 --retag bt709` (stream copy; re-encodes only if the copy can't carry the retagged colour info — check `reencoded` in `--json`) |
 | "brighten it a touch / punch up the contrast and saturation / fix the white balance" | `color.py input.mp4 --correct --exposure 0.3 --contrast 1.1 --saturation 1.05 --temperature 5600 --tint -0.05` (typed, no filter string) |
 | "clean up the audio", "remove the hiss / room noise" | `audio.py input.mp4 --voice` (speech) or `--denoise` |
 | "add background music under the talking" | `audio.py input.mp4 --music bed.mp3 --duck --fade-out 3` |

--- a/references/scripts.md
+++ b/references/scripts.md
@@ -1,6 +1,6 @@
 # Script reference
 
-Every script prints the same information with `--help`; this file exists so the agent can read several at once. All scripts accept `--dry-run`, `--json`, `--fast`, `--progress`, `-o OUT` -- but `--dry-run` only guarantees nothing is written for writing tools: `sync`/`multicam`/`scenes`/`report` still run ffmpeg/ffprobe to measure or analyse (they just don't write the final artifact), and `verify` accepts the flag but ignores it. Exact per-tool semantics: `contract --json`'s `dry_run` field (or `docs/contract.md`).
+Every script prints the same information with `--help`; this file exists so the agent can read several at once. All scripts accept `--dry-run`, `--json`, `--fast`, `--progress`, `-o OUT` -- but `--dry-run` only guarantees nothing is written for writing tools: `probe` (read-only, `--dry-run` changes nothing) and `check` (skips only the loudness-measurement pass) still run ffprobe/ffmpeg, `sync`/`multicam`/`scenes`/`report` still run ffmpeg/ffprobe to measure or analyse (they just don't write the final artifact), and `verify` accepts the flag but ignores it entirely. Exact per-tool semantics: `contract --json`'s `dry_run` field (or `docs/contract.md`).
 
 ## Contents
 - probe.py — inspect


### PR DESCRIPTION
## Summary

Two small follow-ups from external review of the recent #82 (dry-run overclaim) and #73/#78 (`color.py --retag` fallback) fixes.

1. **SKILL.md's intro line already correctly listed `probe`/`check`/`verify` among the dry-run exceptions, but workflow step 3 and `references/scripts.md` only mentioned `sync`/`multicam`/`scenes`/`report`.** An agent reading step 3 alone (the section it's told to always follow) would miss that `probe`/`check` still run real ffprobe/loudness passes under `--dry-run`, and that `verify` ignores the flag entirely. Both locations now match the intro line's completeness. Also added one sentence: trust `--json` over a dry-run's human-readable summary line for any number after the plan (see #77 — that line's dimensions can be a placeholder, not a computed preview of the actual plan).

2. **SKILL.md's Request→script table still said `--retag bt709` is "(no re-encode)" unconditionally.** Since #73's fix, `--json` now reports whether the copy attempt actually succeeded or fell back to a re-encode (`reencoded`/`dropped_non_av_streams` fields). Updated the one-line description to point at that field instead of asserting a guarantee the tool itself no longer makes unconditionally.

Also reopened #77 with a status-update comment: the human-readable dry-run summary line's `1920x1080` placeholder is still present (a first fix was reverted after it caused a real `ZeroDivisionError` regression in `render.py`'s multi-stage pipeline via `join.py`'s aspect math) — `--json` was never affected and stays trustworthy, but the plain-text line itself is still misleading and this issue stays open as a real, lower-priority follow-up rather than closed.

## Test plan
- [x] `python3 tests/test_contract.py` — 60/60 pass (1 pre-existing skip), including the doc-drift tests added in #82's fix

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013tPrsGXLuaGU7t643QNUZs

---
_Generated by [Claude Code](https://claude.ai/code/session_013tPrsGXLuaGU7t643QNUZs)_