### PR TITLE
Fix join.py/fit.py aspect-ratio division by zero, restore honest dry-run dims

### DIFF
--- a/scripts/_common.py
+++ b/scripts/_common.py
@@ -376,16 +376,16 @@ def probe(path: str, role: str = "input") -> Dict[str, Any]:
         if role == "output" and not STATE["dry_run"]:
             _output_failed(path, "not written")
         if STATE["dry_run"]:
-            # width/height/fps are plausible-looking placeholders (not a real measurement), echoed
-            # verbatim into some tools' dry-run summary line regardless of what was actually
-            # planned -- cosmetic, tracked as #77. They CANNOT be changed to 0 (tried this,
-            # reverted): several tools chain dry-run probes across multi-stage pipelines
-            # (join.py's width/height-from-aspect math, for one) and divide by these values, so a
-            # zero placeholder trades a misleading text label for a real ZeroDivisionError crash --
-            # strictly worse. A correct fix needs each such call site to handle "unknown" rather
-            # than assuming a divisor, which is broader than this stub can safely do alone.
+            # width/height/fps are honestly 0/0/0.0 -- "not measured", matching duration/size_bytes
+            # below -- because this is a dry run: the file doesn't exist yet, so there is nothing to
+            # probe. Earlier this stub used plausible-looking placeholders (1920x1080x30.0) instead,
+            # which some tools' dry-run summary line echoed verbatim as if it were a real computed
+            # preview (#77). That was reverted once, because a couple of call sites divided by these
+            # values for aspect-ratio math and crashed on a real 0 (join.py, fit.py); those call
+            # sites are now guarded to treat 0 as "unknown" and fall back sanely instead of dividing
+            # by it, so the stub can finally report the honest, unknown value.
             return {"file": path, "dry_run": True, "format": None, "duration": 0.0, "size_bytes": 0, "bitrate": None,
-                    "video": {"codec": None, "width": 1920, "height": 1080, "fps": 30.0, "pix_fmt": None, "hdr": False,
+                    "video": {"codec": None, "width": 0, "height": 0, "fps": 0.0, "pix_fmt": None, "hdr": False,
                               "color_transfer": None, "color_primaries": None, "rotation": 0, "variable_frame_rate_suspected": False},
                     "audio": {"codec": None, "channels": 0, "sample_rate": 0}, "subtitle_streams": 0}
         die(f"input not found: {path}")

--- a/scripts/fit.py
+++ b/scripts/fit.py
@@ -182,19 +182,21 @@ def main() -> int:
 
     # ---- aspect / size
     if args.aspect or args.width or args.height:
-        src_ratio = Fraction(sw, sh)
+        src_ratio = Fraction(sw, sh) if sh else None
         ratio = parse_aspect(args.aspect) if args.aspect else src_ratio
         if args.width and args.height:
             out_w, out_h = even(args.width), even(args.height)
         elif args.width:
             out_w = even(args.width)
-            out_h = even(out_w / ratio)
+            out_h = even(out_w / ratio) if ratio else args.width
         elif args.height:
             out_h = even(args.height)
-            out_w = even(out_h * ratio)
-        else:
+            out_w = even(out_h * ratio) if ratio else args.height
+        elif ratio and src_ratio:
             out_w = even(sw if ratio <= src_ratio else sh * ratio)
             out_h = even(out_w / ratio)
+        else:
+            out_w, out_h = even(sw), even(sh)
         if args.fit == "crop":
             vf.append(f"scale={out_w}:{out_h}:force_original_aspect_ratio=increase")
             vf.append(f"crop={out_w}:{out_h}:(in_w-out_w)*{args.crop_x:g}:(in_h-out_h)*{args.crop_y:g}")

--- a/scripts/join.py
+++ b/scripts/join.py
@@ -121,9 +121,11 @@ def main() -> int:
     if args.width and args.height:
         w, h = args.width, args.height
     elif args.width:
-        w, h = args.width, int(round(args.width * fh / fw))
+        w = args.width
+        h = int(round(args.width * fh / fw)) if fw else args.width
     elif args.height:
-        w, h = int(round(args.height * fw / fh)), args.height
+        h = args.height
+        w = int(round(args.height * fw / fh)) if fh else args.height
     else:
         w, h = fw, fh
     fps = args.fps or first.get("fps") or 30.0

--- a/tests/test_contract.py
+++ b/tests/test_contract.py
@@ -319,19 +319,45 @@ class ContractTests(unittest.TestCase):
         self.assertEqual(self.contract["json_output"]["failure"]["status"], "failed")
 
     def test_dry_run_multistage_pipeline_survives_the_probe_stub(self):
-        """The dry-run stub probe() returns for a not-yet-written output hardcodes a plausible
-        1920x1080/30fps rather than 0x0 -- tried zeroing it (issue #77) to stop it looking like
-        real data in dry-run summary lines, but render.py/join.py chain dry-run probes across
-        pipeline stages and divide by width/height (aspect-ratio math), so a zero placeholder
-        traded a cosmetic issue for a real ZeroDivisionError crash. This pins the crash-free
-        behavior: a join with only --width set (forcing the height-from-aspect division) must
-        not blow up under --dry-run even when its input is itself a dry-run-planned clip that
-        was never actually written."""
+        """The dry-run stub probe() returns for a not-yet-written output honestly reports
+        width/height/fps as 0/0/0.0 ("not measured", issue #77) instead of the plausible-looking
+        1920x1080/30fps placeholder it used to fabricate. render.py/join.py/fit.py chain dry-run
+        probes across pipeline stages and used to divide by width/height for aspect-ratio math,
+        which is exactly why the first attempt at zeroing this stub was reverted (real
+        ZeroDivisionError). Each such call site now treats a zero/unknown source dimension as
+        "can't compute a ratio" and falls back sanely instead of dividing by it, so this pins the
+        crash-free behavior: a join with only --width set (forcing the height-from-aspect
+        division) must not blow up under --dry-run even when its input is itself a dry-run-planned
+        clip that was never actually written."""
         doc = json.loads(tool("cut", self.src, "--start", "0", "--end", "2", "-o", self.out("dr_a.mp4"), "--dry-run", "--json").stdout)
         self.assertTrue(doc["dry_run"])
         proc = tool("join", self.out("dr_a.mp4"), self.out("dr_a.mp4"), "--width", "480",
                      "-o", self.out("dr_joined.mp4"), "--dry-run", check=False)
         self.assertEqual(proc.returncode, 0, proc.stderr)
+        proc = tool("fit", self.out("dr_a.mp4"), "--width", "480", "--aspect", "9:16",
+                     "-o", self.out("dr_fit_w.mp4"), "--dry-run", check=False)
+        self.assertEqual(proc.returncode, 0, proc.stderr)
+        proc = tool("fit", self.out("dr_a.mp4"), "--height", "480", "--aspect", "9:16",
+                     "-o", self.out("dr_fit_h.mp4"), "--dry-run", check=False)
+        self.assertEqual(proc.returncode, 0, proc.stderr)
+        proc = tool("fit", self.out("dr_a.mp4"), "--width", "480", "--height", "480",
+                     "-o", self.out("dr_fit_wh.mp4"), "--dry-run", check=False)
+        self.assertEqual(proc.returncode, 0, proc.stderr)
+
+    def test_dry_run_probe_stub_does_not_fabricate_plausible_dimensions(self):
+        """Companion to the crash-safety test above: now that every division site that consumes
+        the dry-run probe stub's width/height guards against zero, the stub itself can go back to
+        reporting the honest "not measured" 0/0/0.0 instead of a fabricated 1920x1080/30fps that
+        looked like a real computed preview in a tool's human-readable dry-run summary line."""
+        import _common
+        _common.STATE["dry_run"] = True
+        try:
+            meta = _common.probe(str(self.out("does_not_exist_and_never_will.mp4")))
+        finally:
+            _common.STATE["dry_run"] = False
+        self.assertEqual(meta["video"]["width"], 0)
+        self.assertEqual(meta["video"]["height"], 0)
+        self.assertEqual(meta["video"]["fps"], 0.0)
 
     def test_dry_run_metadata(self):
         for t in self.contract["tools"]:


### PR DESCRIPTION
## Summary

`_common.py`'s `probe()` dry-run stub returned a plausible-looking `1920x1080`/`30fps` placeholder for a not-yet-written output instead of an honest "not measured" `0/0/0.0`. A prior attempt to zero it (in PR #78) was reverted because `join.py` divides by the probed source width/height when computing the other dimension from an aspect ratio, and several tools chain dry-run probes across pipeline stages (a prior stage's still-unwritten dry-run output gets probed as the next stage's input) — so a zero source dimension reached that division and crashed with `ZeroDivisionError`.

This PR does the root-cause fix instead of reverting again:

- **`join.py`**: computing height-from-width or width-from-height now falls back to the given dimension for both axes when the source width/height is `0` (unknown), rather than dividing by it.
- **`fit.py`**: `Fraction(sw, sh)` is only constructed when `sh` is nonzero — an unknown source aspect ratio is treated as absent rather than raising at construction — and the two divisions that used it fall back to the requested dimension (or the raw, un-ratioed source size when neither `--width`/`--height`/`--aspect` can be resolved) instead of dividing by zero.
- Audited every other tool that touches probed width/height for aspect-ratio math (`check.py`, `crop.py`, `export.py`, `insert.py`, `multicam.py`, `overlay.py`, `proxy.py`, `render.py`, `verify.py`): none of them divide by a probed dimension in Python — they either don't touch it, or hand it straight to an ffmpeg filter (`scale=W:-2`, etc.) where a `0` would be an ffmpeg-runtime concern, moot under `--dry-run` since ffmpeg never runs.

With both division sites safe, the stub's `width`/`height`/`fps` can finally report the honest `0/0/0.0` "not measured" value instead of a placeholder that looked like a real computed preview in a dry-run summary line.

## Test plan

- [x] Extended the existing crash-safety regression (`test_dry_run_multistage_pipeline_survives_the_probe_stub`) to also cover `fit.py`'s three aspect-resolution paths (`--width` only, `--height` only, both).
- [x] Added `test_dry_run_probe_stub_does_not_fabricate_plausible_dimensions`, pinning the stub's return value to `0`/`0`/`0.0`.
- [x] `python3 tests/test_contract.py` — 61/61 pass (1 pre-existing skip).
- [x] `python3 tests/test_all.py` — 128/128 pass.

Closes #77.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013tPrsGXLuaGU7t643QNUZs

---
_Generated by [Claude Code](https://claude.ai/code/session_013tPrsGXLuaGU7t643QNUZs)_