### PR TITLE
Catch CHANGELOG drift automatically; document the pitfall

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,6 +18,12 @@ jobs:
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v4
+        with:
+          # Full history (not the default shallow depth-1 clone): test_contract.py's
+          # test_changelog_mentions_every_closed_issue_since_last_tag walks git log back to the
+          # latest tag to check CHANGELOG.md against "Closes #N" in commit bodies -- a shallow
+          # clone would make that check silently a no-op (no tag reachable to diff against).
+          fetch-depth: 0
       - uses: actions/setup-python@v5
         with:
           python-version: "3.9"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -50,7 +50,8 @@ field addition here is additive.
   consistently instead of silently defaulting to track 0 (or, for `fit.py`, to ffmpeg's own
   implicit "best stream" heuristic, which for audio favours channel count over track order).
   `join.py`/`multicam.py` are out of scope — they combine separate input files, a different
-  problem shape.
+  problem shape. Closes [#62](https://github.com/kajisho5/ffmpeg-skill/issues/62) (the same gap
+  `caption.py`/`audio.py` already closed in [#55](https://github.com/kajisho5/ffmpeg-skill/issues/55)).
 - **`doctor --json` gains a `fonts` field**, informational like `gpu_encoders`: drawtext's default
   font (`caption.py --animate`/`--karaoke`, `graphics.py`) can silently substitute a different
   family when the requested one isn't installed — a drawtext exit code can't detect this

--- a/references/process-pitfalls.md
+++ b/references/process-pitfalls.md
@@ -63,3 +63,23 @@ on the *same* platform in a different way: stop redesigning the fixture. Either 
 the strict assertion to the platform where it's provably correct (keeping a weaker,
 platform-general check — output exists, has the right duration — everywhere), or escalate
 before spending a third CI cycle on it.
+
+## A fix merged after CHANGELOG.md's current-version section was drafted can silently miss it
+
+`CHANGELOG.md`'s `## 0.12.0` section was written once, covering everything merged up to
+that point. Two fixes that closed real issues after that point (#62's `--audio-stream`
+extension via PR #72, #77's dry-run-dims fix via PR #88) landed with no further nudge to
+go back and add a bullet — #62's fix actually got a bullet (its content is genuinely
+described) but the `Closes #62` link was left off, and #77 was missed outright until a
+direct question ("shouldn't this bump the version?") prompted a manual check. Neither was
+caught by CI, because nothing checked CHANGELOG.md against what had actually been closed.
+
+Caught by hand both times, then closed properly with `tests/test_contract.py`'s
+`test_changelog_mentions_every_closed_issue_since_last_tag`, which walks `git log` back to
+the latest release tag, extracts every `Closes #N.` from a commit body, and fails if that
+issue number doesn't appear anywhere in `CHANGELOG.md`. This needs real history (`ci.yml`'s
+`actions/checkout` step now passes `fetch-depth: 0` for exactly this reason — the default
+shallow clone leaves no tag reachable to diff against, which would make the test silently
+skip itself in CI, not fail). If this test ever needs to skip a genuinely changelog-less
+closed issue (a pure process note, a duplicate, a revert of an unreleased change), name the
+exemption in the test itself with a reason — don't just widen the regex or drop the check.

--- a/tests/test_contract.py
+++ b/tests/test_contract.py
@@ -359,6 +359,25 @@ class ContractTests(unittest.TestCase):
         self.assertEqual(meta["video"]["height"], 0)
         self.assertEqual(meta["video"]["fps"], 0.0)
 
+    def test_changelog_mentions_every_closed_issue_since_last_tag(self):
+        """A merged fix can land after CHANGELOG.md's current-version section was already
+        written (this happened for real: #77's fix, PR #88, merged after the 0.12.0 section was
+        drafted and initially missed it -- caught by hand, not by a test, and fixed in a
+        follow-up commit). Every "Closes #N." in a commit body since the last release tag should
+        show up somewhere in CHANGELOG.md; if it doesn't, either the changelog needs an entry or
+        the issue was closed without one on purpose (rare -- e.g. a pure process/doc note) and
+        this test's exemption set below should say why. Needs real git history: skips itself on
+        a shallow clone (see ci.yml's fetch-depth: 0) where no tag is reachable at all."""
+        tags = sh("git", "tag", "--list", "v*", "--sort=-creatordate", cwd=ROOT, check=False).stdout.split()
+        if not tags:
+            self.skipTest("no reachable release tag (shallow clone?) -- nothing to diff against")
+        last_tag = tags[0]
+        log = sh("git", "log", f"{last_tag}..HEAD", "--format=%B----COMMIT----", cwd=ROOT, check=False).stdout
+        closed = sorted(set(int(n) for n in re.findall(r"(?im)^closes\s+#(\d+)\.?\s*$", log)))
+        changelog = (ROOT / "CHANGELOG.md").read_text(encoding="utf-8")
+        missing = [n for n in closed if f"#{n}" not in changelog]
+        self.assertEqual(missing, [], f"issue(s) closed since {last_tag} but not mentioned in CHANGELOG.md: {missing}")
+
     def test_dry_run_metadata(self):
         for t in self.contract["tools"]:
             has_flag = "dry_run" in t["input_schema"]["properties"]


### PR DESCRIPTION
## Summary

Two real CHANGELOG gaps happened this session with nothing catching them: #62's fix (PR #72) had a bullet describing its content but never linked "Closes #62", and #77's fix (PR #88) was missed from `CHANGELOG.md`'s `## 0.12.0` section entirely until a direct question ("shouldn't this bump the version?") prompted a manual check (fixed in PR #89).

This adds an automated guard instead of relying on remembering next time:

- **`tests/test_contract.py`**: `test_changelog_mentions_every_closed_issue_since_last_tag` walks `git log` back to the latest release tag, extracts every `Closes #N.` from a commit body, and fails if that issue number isn't mentioned anywhere in `CHANGELOG.md`. Running it against current history found and this PR fixes the #62 link gap (#77 is already covered by PR #89).
- **`.github/workflows/ci.yml`**: `actions/checkout` now passes `fetch-depth: 0` (full history) instead of the default shallow depth-1 clone — the new test needs a reachable tag to diff against; without full history it would silently skip itself in CI with no signal that it wasn't actually checking anything.
- **`references/process-pitfalls.md`**: new entry recording the mistake, matching that file's existing "process mistake made once" format.

## Test plan

- [x] `python3 tests/test_contract.py` — 62/62 pass (1 pre-existing skip), including the new test against real history (with the #62 link fix in place).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013tPrsGXLuaGU7t643QNUZs

---
_Generated by [Claude Code](https://claude.ai/code/session_013tPrsGXLuaGU7t643QNUZs)_