### PR TITLE
README: surface SPEC near the top

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,12 @@ npx ffmpeg-skill
 
 If `ffmpeg` and `python3` are on your PATH, it works: offline, on footage you would rather not upload.
 
+> **SPEC** (Self-Producing Execution Contract), coined by this project's author
+> [kajisho5](https://github.com/kajisho5): each tool's `input_schema` — the part of its contract
+> and MCP tool definition that has to track the CLI flag-for-flag — is never hand-authored beside
+> the code. It's derived, at run time, from the same `argparse` parser that already defines the
+> CLI, and CI fails the build if any of it drifts. → [full explanation](#what-is-spec)
+
 ---
 
 ## Standalone, and in an ecosystem


### PR DESCRIPTION
Docs-only. Adds a short callout right after the intro paragraph (before "Standalone, and in an ecosystem") naming SPEC and linking to the full explanation already in "Built for agents" → "What is SPEC?" (added in #98), instead of leaving the name buried further down the page.

Kept the teaser's claim scoped to what's actually parser-derived (`input_schema`), matching the accuracy fix CodeRabbit asked for on the full explanation in #98, rather than restating the broader "single source of truth" claim that got walked back there.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013tPrsGXLuaGU7t643QNUZs

---
_Generated by [Claude Code](https://claude.ai/code/session_013tPrsGXLuaGU7t643QNUZs)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Added an introduction to the SPEC concept in the README.
  - Documented how command-line input definitions remain aligned with tool input schemas.
  - Noted that automated checks detect inconsistencies and linked to the full “What is SPEC?” section.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->