### PR TITLE
add .npmignore: stop shipping __pycache__ in the npm tarball

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,0 +1,8 @@
+# Compiled Python bytecode caches: interpreter-specific, never meant to ship.
+# package.json's "files" array already scopes the tarball to bin/, scripts/, mcp/, references/,
+# SKILL.md, README.md and LICENSE -- this excludes junk *within* those directories that npm's own
+# default ignore list doesn't cover (unlike .gitignore, an .npmignore is honored even when "files"
+# is set, per npm's own docs: https://docs.npmjs.com/cli/v10/configuring-npm/package-json#files).
+__pycache__/
+*.pyc
+*.pyo

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,16 @@
 
 (nothing yet)
 
+## 0.12.6 — stop shipping `__pycache__` in the npm tarball
+
+`package.json`'s `files` array scopes the tarball to `bin/`, `scripts/`, `mcp/`, `references/`,
+`SKILL.md`, `README.md` and `LICENSE`, but a `files`-scoped pack does not automatically respect
+`.gitignore` the way a plain `git`-tracked-files pack would — the 0.12.5 tarball on npm shipped
+every `scripts/__pycache__/*.pyc` a local interpreter had produced (interpreter-version-specific,
+harmless at runtime since Python regenerates them, but ~45% of the package's unpacked size for
+nothing). Added an explicit `.npmignore` for `__pycache__/`, `*.pyc`, `*.pyo`, which npm honors
+even when `files` is set. Unpacked size drops from 913.7 kB / 64 files to 496.8 kB / 40 files.
+
 ## 0.12.5 — fix Windows `drawtext` crash (#100), and 4 smaller review findings
 
 `look.py`, `scenes.py --sheet`, `overlay.py --text` and `graphics.py` could crash on real Windows

--- a/docs/contract.md
+++ b/docs/contract.md
@@ -21,7 +21,7 @@ The contract is derived from the code that runs, not maintained beside it:
 | Field | Meaning | Changes when |
 |---|---|---|
 | `contract_version` | shape of this document (`1.0`) | a key is renamed, removed or changes meaning |
-| `skill.version` | the npm / package.json version (`0.12.5`) | any release |
+| `skill.version` | the npm / package.json version (`0.12.6`) | any release |
 
 A release that adds a tool or a flag keeps `contract_version`; a breaking change to the
 ToolSpec shape bumps it. Consumers pin on `contract_version` and read `skill.version`
@@ -39,7 +39,7 @@ drifting silently.
 ```json
 {
   "contract_version": "1.0",
-  "skill": {"id": "ffmpeg-skill", "version": "0.12.5", "execution_mode": "local", "kind": "execution",
+  "skill": {"id": "ffmpeg-skill", "version": "0.12.6", "execution_mode": "local", "kind": "execution",
             "entrypoints": {"cli": "...", "mcp": "...", "contract": "...", "doctor": "..."},
             "not_provided": ["AI reasoning", "decisions", "production plans", "project IR", "approvals", "network access", "transcription engine"]},
   "requirements": {"python": ">=3.9 (standard library only)", "ffmpeg": ">=5.0", "ffprobe": ">=5.0"},

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ffmpeg-skill",
-  "version": "0.12.5",
+  "version": "0.12.6",
   "description": "Agent Skill that gives coding agents (Claude Code, Cursor, Codex) a local video editor: 28 FFmpeg tools with a machine-readable contract, contract-derived MCP server, FFmpeg capability detection, probe-first / verify-last workflow. Cut, join, silence removal, fit, captions and karaoke, overlays, motion graphics, HDR to SDR, LUTs, audio clean-up and typed dynamics, sync with drift correction, multicam, loudness, delivery checks, project rendering, batch. No API keys, no cloud, no dependencies.",
   "keywords": [
     "ffmpeg",


### PR DESCRIPTION
Follow-up to publishing 0.12.5: the tarball on npm turned out to include every `scripts/__pycache__/*.pyc` a local interpreter had produced — interpreter-version-specific bytecode Python regenerates on its own, but ~45% of the package's unpacked size for nothing.

`package.json`'s `files` array scopes the tarball, but a `files`-scoped pack does not automatically respect `.gitignore` the way a plain `git`-tracked-files pack would. Added an explicit `.npmignore` (`__pycache__/`, `*.pyc`, `*.pyo`), which npm honors even when `files` is set.

Verified with `npm pack --dry-run`: unpacked size drops from 913.7 kB / 64 files to 496.8 kB / 40 files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013tPrsGXLuaGU7t643QNUZs

---
_Generated by [Claude Code](https://claude.ai/code/session_013tPrsGXLuaGU7t643QNUZs)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Improvements**
  - Published npm packages are now smaller by excluding Python cache and compiled bytecode files.
  - Package contents were reduced from approximately 913.7 kB across 64 files to 496.8 kB across 40 files.

- **Documentation**
  - Added changelog details for version 0.12.6.
  - Updated the documented contract version to 0.12.6.

- **Release**
  - Updated the package version to 0.12.6.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->