### PR TITLE
Fix input deletion after failed ffprobe inspection

### DIFF
--- a/scripts/_common.py
+++ b/scripts/_common.py
@@ -205,6 +205,10 @@ def _cleanup_partial_output(cmd: Sequence[str]) -> None:
     success path, so a failed run() call never routed through it. Remove whatever ffmpeg managed
     to write so a caller scanning the output directory after a failure never mistakes a partial
     artifact for a real (if unverified) one."""
+    # run() also executes ffprobe, whose last argument is an INPUT. Never
+    # interpret a read-only tool's failure as permission to remove that file.
+    if not _is_ffmpeg(cmd):
+        return
     output = cmd[-1]
     if output in ("-", "pipe:0", "pipe:1") or output.startswith("pipe:") or output.startswith("-"):
         return

--- a/tests/test_contract.py
+++ b/tests/test_contract.py
@@ -44,6 +44,24 @@ def tool(name, *args, **kw):
 TONE = "0.5*sin(2*PI*440*t)*gt(sin(2*PI*0.37*t)\\,0.2)+0.3*sin(2*PI*660*t)*gt(sin(2*PI*0.53*t+1)\\,0.6)"
 
 
+@unittest.skipUnless(shutil.which("ffprobe"), "ffprobe not on PATH")
+class ProbeInputPreservationTests(unittest.TestCase):
+    def test_failed_probe_preserves_input(self):
+        # Use real ffprobe and independent fixtures: every failure mode must leave
+        # even an unreadable original byte-for-byte intact.
+        for flags in ([], ["--dry-run"], ["--progress"], ["--dry-run", "--progress"]):
+            with self.subTest(flags=flags), tempfile.TemporaryDirectory() as tmp:
+                source = Path(tmp) / "corrupt.mp4"
+                original = b"not a valid MP4; preserve this original\n"
+                source.write_bytes(original)
+                proc = tool("probe", source, "--json", *flags, check=False)
+                self.assertNotEqual(proc.returncode, 0)
+                self.assertIn("ffprobe failed", proc.stderr)
+                self.assertEqual(json.loads(proc.stdout)["status"], "failed")
+                self.assertTrue(source.exists(), "failed inspection deleted the input")
+                self.assertEqual(source.read_bytes(), original)
+
+
 class ContractTests(unittest.TestCase):
     @classmethod
     def setUpClass(cls):


### PR DESCRIPTION
## Summary

Prevent failed ffprobe inspections from deleting their input files, including under `--dry-run`.

`_run_captured()` calls `_cleanup_partial_output()` on any subprocess failure, including ffprobe. The cleanup helper treats the last argument as an output path and removes it. For the probe command, that argument is the original input. An unreadable/corrupt media file is therefore deleted by an operation intended to be read-only.

This focused fix guards cleanup with the existing `_is_ffmpeg()` predicate. FFmpeg partial-output cleanup is unchanged; ffprobe failures retain the existing nonzero exit and structured error without deleting the source. No CLI or contract schema changes.

## Regression coverage

The new test uses real ffprobe and an independent temporary invalid MP4 for each of four flag combinations: normal, `--dry-run`, `--progress`, and both flags. It checks the failure response and byte-for-byte input preservation. All four subcases failed before the fix because the input disappeared, and all four pass afterward. No user media is used.

## Validation

Final rerun after installing Homebrew `ffmpeg-full` 9.0.1 on macOS (Python 3.14.6): **`npm test` PASS** — 138 end-to-end tests (1 skipped) and 68 contract tests (1 skipped), exit 0. This includes the new preservation regression and existing partial-output cleanup tests. The run selected `/opt/homebrew/opt/ffmpeg-full/bin` first on PATH. `doctor` reports `ok: true`, no missing/unknown capabilities. A non-fatal fontconfig cache-directory warning appeared under the filesystem sandbox. Cross-platform CI is still required.

Earlier validation before the FFmpeg environment upgrade:

- PASS: `python3 tests/test_contract.py ProbeInputPreservationTests`
- PASS: focused run including the new test plus `ContractTests.test_ffmpeg_failure_after_opening_the_output_leaves_nothing_behind` and `ContractTests.test_ffmpeg_failures_are_loud` (3 tests).
- PASS: `git diff --check`.
- Full contract suite: 68 tests, 6 failures, 1 skipped on macOS with Python 3.14.6 / Homebrew FFmpeg 8.1.2. The environment lacks drawtext, subtitles, vidstabdetect, vidstabtransform, and zscale; failures include media-rendering and doctor/font capability expectations. Not claiming a green full suite.
- `npm test`: the end-to-end suite finished with 138 tests, 24 failures, 1 skipped (including unavailable-filter failures); its nonzero exit prevents the chained contract run, so the contract suite was run separately above. Cross-platform CI remains required.

## Scope

This addresses deletion caused by failed non-FFmpeg subprocesses. It does not redesign FFmpeg output ownership/overwrite policy or MCP sandboxing. Please do not treat this narrowly scoped fix as a complete file-safety audit.
