### PR TITLE
Skip the new font-injection regression test on Windows CI

### DIFF
--- a/tests/test_all.py
+++ b/tests/test_all.py
@@ -1595,6 +1595,12 @@ class FFmpegSkillTests(unittest.TestCase):
         script("overlay.py", self.src, "--text", "hi", "--box-color", "black@0.5", "-o", OUT / "colorok5.mp4")
 
     # ---------------------------------------------------------------- font-name filter-graph injection (adversarial)
+    @unittest.skipIf(platform.system() == "Windows", "forces the fc-match-missing fallback path by symlinking just "
+                      "ffmpeg/ffprobe into a stub PATH dir -- os.symlink needs an elevated/dev-mode privilege on "
+                      "Windows that CI runners don't grant, and default_font_file() doesn't even consult fc-match "
+                      "there (it resolves a fixed arial.ttf under WINDIR, see its docstring), so this specific "
+                      "repro doesn't generalise to Windows. The fix itself (escape_drawtext() around the fallback "
+                      "value) is plain string handling with no OS branch, so it's equally in effect there.")
     def test_font_flag_escapes_filter_graph_injection_when_unresolved(self):
         """overlay.py and graphics.py both accept --font as a family NAME, not a file path, and try
         to resolve it to a concrete file via default_font_file() (fc-match) first -- but that


### PR DESCRIPTION
## Summary

#108's Windows CI job failed after merge: `test_font_flag_escapes_filter_graph_injection_when_unresolved` forces the `fc-match`-missing fallback path in `overlay.py` by symlinking just `ffmpeg`/`ffprobe` into a stub `PATH` directory. That fails on `windows-latest` (`error: 'ffprobe' was not found on PATH`) because `os.symlink` needs an elevated/dev-mode privilege on Windows that CI runners don't grant.

The repro doesn't generalise to Windows for an unrelated reason too: `default_font_file()` never consults `fc-match` there at all — per its own docstring, it resolves a fixed `arial.ttf` under `WINDIR` instead. The actual fix (wrapping the `font=` fallback value with `escape_drawtext()`) is plain string handling with no OS branch, so it's equally in effect on Windows — only this specific symlink-based way of forcing the vulnerable branch is POSIX-only.

Skipped with `@unittest.skipIf(platform.system() == "Windows", ...)`, matching the exact convention this test file already uses for its other POSIX-shim-based tests (see the doctor-detection fake-ffmpeg shim tests).

## Test plan

- [x] `python3 tests/test_all.py` — full suite, 184 tests, OK
- [x] `python3 tests/test_contract.py` — 67 tests, OK
- [x] Confirmed the test still runs (and passes) on Linux — only the Windows leg is skipped

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013tPrsGXLuaGU7t643QNUZs

---
_Generated by [Claude Code](https://claude.ai/code/session_013tPrsGXLuaGU7t643QNUZs)_