### PR TITLE
CI: retry Windows ffmpeg install on Chocolatey's transient 503s

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,7 +39,20 @@ jobs:
           echo "$(brew --prefix ffmpeg-full)/bin" >> "$GITHUB_PATH"
       - name: Install ffmpeg (Windows)
         if: runner.os == 'Windows'
-        run: choco install ffmpeg -y --no-progress
+        # The Chocolatey community feed (community.chocolatey.org) intermittently 503s under load
+        # -- seen repeatedly failing CI with nothing wrong in the PR's own diff. Retry with backoff
+        # instead of failing the whole job on what's usually a transient upstream blip.
+        shell: pwsh
+        run: |
+          $attempts = 5
+          for ($i = 1; $i -le $attempts; $i++) {
+            choco install ffmpeg -y --no-progress
+            if ($LASTEXITCODE -eq 0) { break }
+            if ($i -eq $attempts) { exit $LASTEXITCODE }
+            $delay = 15 * $i
+            Write-Host "choco install ffmpeg failed (attempt $i/$attempts, exit $LASTEXITCODE) -- retrying in ${delay}s"
+            Start-Sleep -Seconds $delay
+          }
       - name: ffmpeg version, listings and doctor
         shell: bash
         run: |


### PR DESCRIPTION
## Summary

`community.chocolatey.org` has intermittently returned `503 Service Unavailable` on `choco install ffmpeg`, failing the whole Windows CI job with nothing wrong in the PR's own diff. Hit repeatedly today across #113, #116, and #118, each requiring a manual re-run once the other two OSes were already green.

## Fix

Retry the `choco install ffmpeg` step up to 5 times with linear backoff (15s, 30s, 45s, 60s) before actually failing the job, instead of a single attempt with no resilience to a known-flaky upstream feed.

## Test plan

- [x] `python3 -c "import yaml; yaml.safe_load(open('.github/workflows/ci.yml'))"` — YAML is valid
- [x] This is a CI-only change (no script/test changes) — verified by re-reading the diff; the retry loop is a straightforward wrap around the existing `choco install ffmpeg -y --no-progress` command, same install behavior on success
- [ ] Will confirm the Windows job itself still installs ffmpeg successfully once this PR's own CI runs

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013tPrsGXLuaGU7t643QNUZs

---
_Generated by [Claude Code](https://claude.ai/code/session_013tPrsGXLuaGU7t643QNUZs)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Improved the Windows setup process for FFmpeg installation in CI by adding automatic retries.
  - Installation attempts now pause between retries and report a failure if all attempts are unsuccessful.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->