### PR TITLE
Fix the MCP server crashing on a non-object JSON-RPC line

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,19 @@
 
 (nothing yet)
 
+## 0.16.6 — fix the MCP server crashing on a non-object JSON-RPC line
+
+`mcp/server.py`'s stdio loop parsed each line with `json.loads()`, which
+accepts any valid JSON value, not just an object -- a bare `42`, `null`,
+`true` or `[1,2,3]` line parses without error. The very next check,
+`"id" not in req`, then raised an uncaught `TypeError` for a non-dict
+`req` (an int/bool/None isn't iterable the way `in` needs). That check
+sat outside the `try/except` wrapping `handle()`, so the exception
+propagated out of the stdin loop and killed the entire stdio server
+process -- not just that one malformed line, but every other in-flight
+and future tool call in the session along with it. Fixed by skipping any
+parsed JSON value that isn't a dict before the `"id" not in req` check.
+
 ## 0.16.4 — fix a silent false-PASS in check.py, an infinite loop in multicam.py, and a silent output collision in batch.py
 
 Three unrelated bugs found in a wider audit past `caption.py`:

--- a/docs/contract.md
+++ b/docs/contract.md
@@ -21,7 +21,7 @@ The contract is derived from the code that runs, not maintained beside it:
 | Field | Meaning | Changes when |
 |---|---|---|
 | `contract_version` | shape of this document (`1.0`) | a key is renamed, removed or changes meaning |
-| `skill.version` | the npm / package.json version (`0.16.4`) | any release |
+| `skill.version` | the npm / package.json version (`0.16.6`) | any release |
 
 A release that adds a tool or a flag keeps `contract_version`; a breaking change to the
 ToolSpec shape bumps it. Consumers pin on `contract_version` and read `skill.version`
@@ -39,7 +39,7 @@ drifting silently.
 ```json
 {
   "contract_version": "1.0",
-  "skill": {"id": "ffmpeg-skill", "version": "0.16.4", "execution_mode": "local", "kind": "execution",
+  "skill": {"id": "ffmpeg-skill", "version": "0.16.6", "execution_mode": "local", "kind": "execution",
             "entrypoints": {"cli": "...", "mcp": "...", "contract": "...", "doctor": "..."},
             "not_provided": ["AI reasoning", "decisions", "production plans", "project IR", "approvals", "network access", "transcription engine"]},
   "requirements": {"python": ">=3.9 (standard library only)", "ffmpeg": ">=5.0", "ffprobe": ">=5.0"},

--- a/mcp/server.py
+++ b/mcp/server.py
@@ -158,6 +158,14 @@ def main() -> int:
             req = json.loads(line)
         except ValueError:
             continue
+        # json.loads accepts any valid JSON value, not just an object -- a bare `42`, `null`,
+        # `true` or `[1,2]` line parses fine but isn't a JSON-RPC request. Without this guard,
+        # "id" not in req raised TypeError for a non-dict req (ints/bools/None aren't iterable
+        # the way `in` needs), uncaught by the try/except below it, killing the whole stdio
+        # server process -- not just failing that one malformed line, but every other in-flight
+        # and future tool call in the session along with it.
+        if not isinstance(req, dict):
+            continue
         if "id" not in req:  # notification
             continue
         try:

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ffmpeg-skill",
-  "version": "0.16.4",
+  "version": "0.16.6",
   "description": "Agent Skill that gives coding agents (Claude Code, Cursor, Codex) a local video editor: 40 FFmpeg tools with a machine-readable contract, contract-derived MCP server, FFmpeg capability detection, probe-first / verify-last workflow. Cut, join, silence removal, fit, captions and karaoke, overlays, motion graphics, HDR to SDR, LUTs, audio clean-up and typed dynamics, sync with drift correction, multicam, loudness, delivery checks, project rendering, batch. No API keys, no cloud, no dependencies.",
   "keywords": [
     "ffmpeg",

--- a/tests/test_all.py
+++ b/tests/test_all.py
@@ -2164,7 +2164,7 @@ class FFmpegSkillTests(unittest.TestCase):
                  json.dumps({"jsonrpc": "2.0", "id": 1, "method": "tools/list"})]
         proc = subprocess.run([sys.executable, str(server)], input="\n".join(lines) + "\n", stdout=subprocess.PIPE, stderr=subprocess.PIPE, text=True)
         self.assertEqual(proc.returncode, 0, f"server must not crash on non-object JSON lines; stderr: {proc.stderr}")
-        resp = [json.loads(l) for l in proc.stdout.splitlines() if l.strip()]
+        resp = [json.loads(response_line) for response_line in proc.stdout.splitlines() if response_line.strip()]
         self.assertEqual(len(resp), 1, "only the one real request should get a response")
         self.assertEqual(resp[0]["id"], 1)
         self.assertIn("tools", resp[0]["result"])

--- a/tests/test_all.py
+++ b/tests/test_all.py
@@ -2069,6 +2069,25 @@ class FFmpegSkillTests(unittest.TestCase):
         self.assertTrue(resp[6]["result"].get("isError"))
         self.assertEqual(resp[7]["error"]["code"], -32601)
 
+    def test_mcp_server_survives_a_non_object_json_line(self):
+        """json.loads accepts any valid JSON value, not just an object -- a bare `42`, `null`,
+        `true` or `[1,2]` line parses without raising, but main()'s very next line, `"id" not in
+        req`, raised an uncaught TypeError for a non-dict req (an int/bool/None isn't iterable the
+        way `in` needs). That check sat outside the try/except wrapping handle(), so the exception
+        propagated out of the stdin loop and killed the whole stdio server process -- not just
+        that one malformed line, but every other in-flight and future tool call in the session.
+        Verify a line like this is now skipped, and the server stays alive and answers the next
+        (valid) request instead of exiting non-zero with nothing produced for it."""
+        server = ROOT / "mcp" / "server.py"
+        lines = ["42", "null", "true", "[1,2,3]",
+                 json.dumps({"jsonrpc": "2.0", "id": 1, "method": "tools/list"})]
+        proc = subprocess.run([sys.executable, str(server)], input="\n".join(lines) + "\n", stdout=subprocess.PIPE, stderr=subprocess.PIPE, text=True)
+        self.assertEqual(proc.returncode, 0, f"server must not crash on non-object JSON lines; stderr: {proc.stderr}")
+        resp = [json.loads(l) for l in proc.stdout.splitlines() if l.strip()]
+        self.assertEqual(len(resp), 1, "only the one real request should get a response")
+        self.assertEqual(resp[0]["id"], 1)
+        self.assertIn("tools", resp[0]["result"])
+
     def test_batch_recipe_and_cache(self):
         folder = OUT / "batch_in"
         folder.mkdir(exist_ok=True)


### PR DESCRIPTION
## Summary

`mcp/server.py`'s stdio loop parsed each line with `json.loads()`, which accepts any valid JSON value, not just an object — a bare `42`, `null`, `true` or `[1,2,3]` line parses without error. The very next check, `"id" not in req`, then raised an uncaught `TypeError` for a non-dict `req` (an int/bool/None isn't iterable the way `in` needs). That check sat outside the `try/except` wrapping `handle()`, so the exception propagated out of the stdin loop and **killed the entire stdio server process** — not just that one malformed line, but every other in-flight and future tool call in the session along with it.

## Fix

Skip any parsed JSON value that isn't a dict before the `"id" not in req` check.

## Test plan

- [x] New regression test `test_mcp_server_survives_a_non_object_json_line`: sends `42`, `null`, `true`, `[1,2,3]` followed by a real `tools/list` request; verifies the server exits 0 and still answers the valid request
- [x] Verified pre-fix: `echo 42 | python3 mcp/server.py` crashed with a traceback and exit 1
- [x] Verified post-fix: same input exits 0
- [x] `python3 tests/test_all.py` — 199 tests, OK (1 new)
- [x] `python3 tests/test_contract.py` — 68 tests, OK
- [x] Version bumped to 0.16.6 (`package.json`, `docs/contract.md`; 0.16.5 is reserved by an in-flight PR), `CHANGELOG.md` updated

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013tPrsGXLuaGU7t643QNUZs

---
_Generated by [Claude Code](https://claude.ai/code/session_013tPrsGXLuaGU7t643QNUZs)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * MCP stdio servers now remain running when receiving valid JSON values that are not request objects.
  * Fixed single-clip fitting when a project specifies a frame height.
  * Fixed multicam drift correction so audio trimming is applied at the correct time.

* **Documentation**
  * Updated the documented skill version to 0.16.9.

* **Release**
  * Updated the package and changelog version to 0.16.9.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->