### PR TITLE
Add release-drafter: a running draft release, updated as PRs merge

### DIFF
--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -1,0 +1,48 @@
+# Config for release-drafter/release-drafter. Maintains a running DRAFT release (updated on
+# every push to main) summarizing merged PRs since the last tag -- a cross-check against
+# CHANGELOG.md's hand-written notes, not a replacement for them. Actual publishing still stays a
+# deliberate, manual act: tag a commit (`git tag vX.Y.Z && git push origin vX.Y.Z`), which
+# .github/workflows/release.yml picks up and publishes using CHANGELOG.md's own section for that
+# version. This draft is never auto-published.
+name-template: "v$RESOLVED_VERSION"
+tag-template: "v$RESOLVED_VERSION"
+categories:
+  - title: "Fixes"
+    labels:
+      - fix
+      - bug
+  - title: "Features"
+    labels:
+      - feature
+      - enhancement
+  - title: "Other changes"
+    labels:
+      - chore
+      - docs
+      - ci
+change-template: "- $TITLE (#$NUMBER)"
+change-title-escapes: '\<*_&'
+version-resolver:
+  major:
+    labels:
+      - major
+  minor:
+    labels:
+      - minor
+      - feature
+      - enhancement
+  patch:
+    labels:
+      - patch
+      - fix
+      - bug
+      - chore
+      - docs
+      - ci
+  default: patch
+template: |
+  ## What's Changed
+
+  $CHANGES
+
+  Cross-check this against CHANGELOG.md's own entry for this version before tagging a release.

--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -2,13 +2,17 @@
 # purely a convenience cross-check against CHANGELOG.md's hand-written notes -- it never publishes
 # anything itself; publishing a real release stays the deliberate, manual `git tag` act described
 # in release.yml / README's "Development" -> "Releasing" section.
+#
+# push-to-main only, deliberately: release-drafter reads its config from the DEFAULT branch, so a
+# pull_request trigger fails with "Configuration file .github/release-drafter.yml is not found"
+# for any PR that hasn't merged yet (a chicken-and-egg problem for the very PR that first adds
+# this file, and for any PR opened before this config lands on main). The per-PR "next version"
+# preview a pull_request trigger would add isn't essential to what this workflow is actually for.
 name: release-drafter
 
 on:
   push:
     branches: [main]
-  pull_request:
-    types: [opened, reopened, synchronize]
 
 permissions:
   contents: read

--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -1,0 +1,25 @@
+# Keeps a draft GitHub Release up to date with merged-PR summaries as main moves forward. This is
+# purely a convenience cross-check against CHANGELOG.md's hand-written notes -- it never publishes
+# anything itself; publishing a real release stays the deliberate, manual `git tag` act described
+# in release.yml / README's "Development" -> "Releasing" section.
+name: release-drafter
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    types: [opened, reopened, synchronize]
+
+permissions:
+  contents: read
+
+jobs:
+  update_release_draft:
+    permissions:
+      contents: write
+      pull-requests: write
+    runs-on: ubuntu-latest
+    steps:
+      - uses: release-drafter/release-drafter@v6
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Summary

Adds [release-drafter](https://github.com/release-drafter/release-drafter): maintains a running **draft** GitHub Release that auto-updates on every push to `main` and PR event, summarizing merged PRs into categorized notes (Fixes / Features / Other changes, by label).

This is purely a convenience cross-check against `CHANGELOG.md`'s hand-written notes — **it never publishes anything itself**. Publishing a real release stays the deliberate, manual `git tag vX.Y.Z && git push origin vX.Y.Z` act `release.yml` already automates the GitHub Release step for, per README's "Development" → "Releasing" section. The two workflows don't conflict: `release-drafter.yml` only ever touches a draft; `release.yml` only fires on an actual version tag push.

## Test plan

- [x] `python3 -c "import yaml; yaml.safe_load(...)"` — both new YAML files are valid
- [x] This is CI-config-only (no script/test changes)
- [ ] Will confirm the workflow runs successfully once this PR merges to `main` and creates its first draft

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013tPrsGXLuaGU7t643QNUZs

---
_Generated by [Claude Code](https://claude.ai/code/session_013tPrsGXLuaGU7t643QNUZs)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added automated draft release management for changes merged into the main branch.
  * Draft releases now organize entries by change type and calculate semantic versions.
  * Release publication remains a manual step using tagged releases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->