### PR TITLE
Add a Sponsor badge to the top badge row

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@
   <img src="https://img.shields.io/badge/python-3.9%2B-blue" alt="Python 3.9+">
   <img src="https://img.shields.io/badge/ffmpeg-5.0%2B-orange" alt="FFmpeg 5.0+">
   <a href="LICENSE"><img src="https://img.shields.io/badge/license-MIT-green" alt="MIT"></a>
+  <a href="https://github.com/sponsors/kajisho5"><img src="https://img.shields.io/badge/sponsor-%E2%9D%A4-ea4aaa?logo=githubsponsors" alt="Sponsor"></a>
 </p>
 
 ```bash


### PR DESCRIPTION
## Summary

The README already links GitHub Sponsors in its bottom "Support" section, but nothing surfaced it at the top where the other badges (CI, npm, license) live. Added a Sponsor badge next to them.

## Test plan

- [x] No code changes, README-only
- [x] Badge follows the same markup pattern as the existing badges

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013tPrsGXLuaGU7t643QNUZs

---
_Generated by [Claude Code](https://claude.ai/code/session_013tPrsGXLuaGU7t643QNUZs)_