### PR TITLE
Bump version to 0.16.12 to exercise the release automation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,18 @@
 
 (nothing yet)
 
+## 0.16.12 — verify the fully-automated release pipeline end to end
+
+No functional code changes. `.github/workflows/release.yml` was rewritten to
+auto-create the git tag, GitHub Release, and npm publish on every push to
+`main` that bumps `package.json`'s version, but the first real run of it
+(for 0.16.11) never got an npm publish to succeed: the `NPM_TOKEN` secret
+wasn't valid yet, and once the tag existed the workflow's own guard
+prevented a clean re-attempt under the same version. This bump exists
+solely to give the pipeline a fresh, untagged version to run against so
+the whole chain — tag, GitHub Release, and npm publish — can be verified
+working in one pass.
+
 ## 0.16.11 — fix a contract/reality mismatch on AAC, three batch.py/render.py reliability bugs, and a non-atomic installer
 
 Continuing the same external audit report's architecture/data-integrity/reliability findings:

--- a/docs/contract.md
+++ b/docs/contract.md
@@ -21,7 +21,7 @@ The contract is derived from the code that runs, not maintained beside it:
 | Field | Meaning | Changes when |
 |---|---|---|
 | `contract_version` | shape of this document (`1.0`) | a key is renamed, removed or changes meaning |
-| `skill.version` | the npm / package.json version (`0.16.11`) | any release |
+| `skill.version` | the npm / package.json version (`0.16.12`) | any release |
 
 A release that adds a tool or a flag keeps `contract_version`; a breaking change to the
 ToolSpec shape bumps it. Consumers pin on `contract_version` and read `skill.version`
@@ -39,7 +39,7 @@ drifting silently.
 ```json
 {
   "contract_version": "1.0",
-  "skill": {"id": "ffmpeg-skill", "version": "0.16.11", "execution_mode": "local", "kind": "execution",
+  "skill": {"id": "ffmpeg-skill", "version": "0.16.12", "execution_mode": "local", "kind": "execution",
             "entrypoints": {"cli": "...", "mcp": "...", "contract": "...", "doctor": "..."},
             "not_provided": ["AI reasoning", "decisions", "production plans", "project IR", "approvals", "network access", "transcription engine"]},
   "requirements": {"python": ">=3.9 (standard library only)", "ffmpeg": ">=5.0", "ffprobe": ">=5.0"},

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ffmpeg-skill",
-  "version": "0.16.11",
+  "version": "0.16.12",
   "description": "Agent Skill that gives coding agents (Claude Code, Cursor, Codex) a local video editor: 40 FFmpeg tools with a machine-readable contract, contract-derived MCP server, FFmpeg capability detection, probe-first / verify-last workflow. Cut, join, silence removal, fit, captions and karaoke, overlays, motion graphics, HDR to SDR, LUTs, audio clean-up and typed dynamics, sync with drift correction, multicam, loudness, delivery checks, project rendering, batch. No API keys, no cloud, no dependencies.",
   "keywords": [
     "ffmpeg",


### PR DESCRIPTION
## Summary
- 0.16.11 got stuck: `release.yml`'s first automated run created the tag and GitHub Release, but npm publish never succeeded (invalid `NPM_TOKEN`), and the workflow's `already_released` guard blocks retrying npm publish under the same version.
- Bumps `package.json`, `docs/contract.md`, and `CHANGELOG.md` to `0.16.12` so the next merge to `main` gives the release automation a fresh, untagged version to run end to end (tag + GitHub Release + npm publish).
- No functional code changes.

## Test plan
- [x] `python3 tests/test_contract.py` — all 70 tests pass
- [ ] After merge, verify `release.yml` on `main` creates tag `v0.16.12`, a GitHub Release, and actually publishes `0.16.12` to the npm registry (not just a green Actions run — verify against `https://registry.npmjs.org/ffmpeg-skill/latest`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013tPrsGXLuaGU7t643QNUZs

---
_Generated by [Claude Code](https://claude.ai/code/session_013tPrsGXLuaGU7t643QNUZs)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Release**
  - Updated the package to version **0.16.12**.
  - This release contains no functional code changes.

- **Documentation**
  - Updated the contract documentation and embedded version references to **0.16.12**.

- **Chores**
  - Improved the release automation for creating releases and publishing updated package versions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->