### PR TITLE
ci: run the test suite on Python 3.13 too (Ubuntu only)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,7 +24,16 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
+        python: ["3.9"]
+        # The docs promise Python 3.9+; 3.9 is the floor and every OS runs it. One extra Linux
+        # job on the newest CPython proves the ceiling too (3.10-3.12 sit between the two; a
+        # stdlib-only codebase that passes on both ends is very unlikely to break in the
+        # middle). Linux only: it bills at 1x, macOS at 10x. See #146.
+        include:
+          - os: ubuntu-latest
+            python: "3.13"
     runs-on: ${{ matrix.os }}
+    name: test (${{ matrix.os }}, py${{ matrix.python }})
     steps:
       - uses: actions/checkout@v4
         with:
@@ -35,7 +44,7 @@ jobs:
           fetch-depth: 0
       - uses: actions/setup-python@v7
         with:
-          python-version: "3.9"
+          python-version: ${{ matrix.python }}
       - name: Install ffmpeg (Linux)
         if: runner.os == 'Linux'
         run: sudo apt-get update && sudo apt-get install -y ffmpeg fonts-dejavu-core
@@ -88,7 +97,7 @@ jobs:
       - uses: actions/upload-artifact@v7
         if: always()
         with:
-          name: ffmpeg-listings-${{ matrix.os }}
+          name: ffmpeg-listings-${{ matrix.os }}-py${{ matrix.python }}
           path: listings/
       - run: python tests/test_all.py
       # A handful of tests here drive the tools through POSIX shell shims (fake ffmpeg on PATH)

--- a/README.md
+++ b/README.md
@@ -312,7 +312,7 @@ npx ffmpeg-skill doctor --json   # available / missing / missing_optional / unkn
 
 ## FFmpeg compatibility
 
-The tools need FFmpeg 5.0 or later and Python 3.9 or later (standard library only). What CI actually exercises on every pull request is FFmpeg 6.1 (Ubuntu), 8.x (macOS) and 9.x (Windows), all on Python 3.9; 5.x and 7.x are expected to work from the filter/encoder names used but are not run ([#146](https://github.com/kajisho5/ffmpeg-skill/issues/146) tracks widening the matrix). The capability parser has been run against the listings of these builds:
+The tools need FFmpeg 5.0 or later and Python 3.9 or later (standard library only). What CI actually exercises on every pull request is FFmpeg 6.1 (Ubuntu), 8.x (macOS) and 9.x (Windows), all on Python 3.9, plus Ubuntu on Python 3.13 (the two ends of the supported range); 5.x and 7.x are expected to work from the filter/encoder names used but are not run ([#146](https://github.com/kajisho5/ffmpeg-skill/issues/146) tracks widening the matrix). The capability parser has been run against the listings of these builds:
 
 | FFmpeg | `-filters` row layout | Source |
 |---|---|---|


### PR DESCRIPTION
## Summary

README and `docs/contract.md` promise Python 3.9+, but CI only ever ran 3.9. This adds one Ubuntu job on the newest CPython (3.13) so both ends of the promised range are proven; a stdlib-only codebase passing on both ends is very unlikely to break in between. Linux only because it bills at 1x (macOS 10x).

- `ci.yml`: `matrix.python: ["3.9"]` plus an `include` for `ubuntu-latest` / `3.13`; job names now read `test (<os>, py<version>)`; artifact names carry the version so the two Ubuntu uploads don't collide.
- README compatibility paragraph updated.

Part of #146 — the FFmpeg 5.x / 7.x half of that issue stays open (needs static builds; separate PR).

## Test plan

- [x] `yaml.safe_load` on `ci.yml`; matrix expands to 4 jobs
- [ ] The new `test (ubuntu-latest, py3.13)` job is green on this PR
- [ ] Merge is a no-op release (`ci:` title → `chore`)

Refs #146, #148.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013tPrsGXLuaGU7t643QNUZs

---
_Generated by [Claude Code](https://claude.ai/code/session_013tPrsGXLuaGU7t643QNUZs)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Expanded automated compatibility testing to include Python 3.13 on Linux.
  * Continued testing Python 3.9 across Linux, macOS, and Windows.

* **Documentation**
  * Updated FFmpeg compatibility documentation to reflect the expanded Python test coverage.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->