### PR TITLE
chore(tests): cover verify.py's full plan and the MCP server's error paths

### DIFF
--- a/tests/test_all.py
+++ b/tests/test_all.py
@@ -2169,6 +2169,85 @@ class FFmpegSkillTests(unittest.TestCase):
         self.assertEqual(out["stages"], ["clips", "join"])
         self.assertTrue(Path(out["output"]).exists())
 
+    def test_render_every_stage_flag_and_every_refusal(self):
+        """render.py's stage branches that test_render_project does not take (silence, captions
+        from srt/ass, graphics, image and logo overlays, audio replace/loop/stereo/mono/downmix,
+        export fit/crf, brand forwarding, the no-export copy path) and its refusals (no project,
+        unreadable project, empty clips, captions/graphics/overlays without their required key,
+        a child script failing) were untested (#147). --dry-run drives every argv-building branch
+        without encoding; the copy path and the child failure run for real on a 2 s clip."""
+        srt = OUT / "render_full.srt"
+        srt.write_text("1\n00:00:00,000 --> 00:00:01,500\nHello\n\n", encoding="utf-8")
+        ass = OUT / "render_full.ass"
+        logo = OUT / "render_full_logo.png"
+        sh("ffmpeg", "-y", "-hide_banner", "-loglevel", "error", "-f", "lavfi", "-i", "color=c=red:s=64x64:d=1", "-frames:v", "1", logo)
+        brand = OUT / "render_full_brand.json"
+        brand.write_text(json.dumps({"logo": logo.name, "logo_position": "top-right", "colors": {"primary": "FF6A00", "text": "FFFFFF"}}), encoding="utf-8")
+        full = {
+            "output": "render_full.mp4",
+            "brand": brand.name,
+            "clips": [{"src": "source.mp4", "in": 0, "out": 2}, {"src": "source.mp4", "in": 2, "out": 4}],
+            "frame": {"width": 640, "height": 360, "fps": 25},
+            "fit": {"duration": 3.5, "method": "trim"},
+            "captions": {"srt": srt.name, "font": "DejaVu Sans", "position": "top", "bold": True, "box": True},
+            "graphics": [{"template": "lower-third", "name": "Ada", "title": "Analyst", "start": 0, "end": 2},
+                         {"template": "title", "title": "T", "subtitle": "S", "start": 0, "end": 1, "position": "top-left"}],
+            "overlays": [{"image": logo.name, "position": "bottom-right", "opacity": 0.5, "scale": 80},
+                         {"logo": True, "start": 0, "end": 1},
+                         {"text": "txt", "font_size": 24, "margin": 12, "box": True}],
+            "audio": {"replace": "long_ref.wav", "music_volume": -12, "gain": 1, "music_loop": True, "stereo": True, "denoise": True},
+            "loudness": {"lufs": -16},
+            "export": {"preset": "youtube", "fit": "pad", "crf": 20},
+        }
+        proj = OUT / "render_full.json"
+        proj.write_text(json.dumps(full), encoding="utf-8")
+        proc = script("render.py", proj, "--dry-run", "--json")
+        plan = json.loads(proc.stdout)
+        self.assertEqual(plan["stages"], ["clips", "join", "fit", "captions", "graphics", "overlays", "audio", "loudness", "export"])
+        forwarded = "\n".join(l for l in proc.stderr.splitlines() if l.startswith("→ "))  # render's own child invocations
+        for needle in ("--srt", "--template lower-third", "--image", "--logo", "--replace", "--music-loop", "--fit pad --crf 20", "--brand"):
+            self.assertIn(needle, forwarded, f"{needle} not forwarded:\n{forwarded}")
+        for stage in ("fit", "captions", "graphics", "overlays", "audio", "loudness"):
+            out = json.loads(script("render.py", proj, "--dry-run", "--stop-after", stage, "--json").stdout)
+            self.assertEqual(out["stages"][-1], stage)
+        # single uncut clip (so silence.py can analyse a real file under --dry-run), silence stage,
+        # captions from .ass, mono/downmix/duck audio, voice flag: the other branches of the same tables
+        alt = dict(full, clips=[{"src": "source.mp4"}], silence={"threshold": -40, "min_silence": 0.4, "margin": 0.1},
+                   captions={"ass": ass.name}, audio={"music": "long_ref.wav", "mono": True, "downmix": True, "duck": True, "voice": True, "duck_amount": 8}, graphics=[], overlays=[])
+        ass.write_text("[Script Info]\nScriptType: v4.00+\n\n[Events]\nFormat: Layer, Start, End, Style, Text\nDialogue: 0,0:00:00.00,0:00:01.00,Default,hi\n", encoding="utf-8")
+        (OUT / "render_full_alt.json").write_text(json.dumps(alt), encoding="utf-8")
+        proc = script("render.py", OUT / "render_full_alt.json", "--dry-run", "--json")
+        self.assertEqual(json.loads(proc.stdout)["stages"], ["clips", "silence", "fit", "captions", "audio", "loudness", "export"])
+        forwarded = "\n".join(l for l in proc.stderr.splitlines() if l.startswith("→ "))
+        for needle in ("--ass", "--min-silence 0.4", "--mono", "--downmix", "--duck-amount 8", "--voice"):
+            self.assertIn(needle, forwarded, f"{needle} not forwarded:\n{forwarded}")
+        out = json.loads(script("render.py", OUT / "render_full_alt.json", "--dry-run", "--stop-after", "silence", "--json").stdout)
+        self.assertEqual(out["stages"], ["clips", "silence"])
+        # no export block: the last stage is copied to the output, for real
+        copy_proj = OUT / "render_copy.json"
+        copy_proj.write_text(json.dumps({"output": "render_copy.mp4", "clips": [{"src": "source.mp4", "in": 0, "out": 2}]}), encoding="utf-8")
+        data = json.loads(script("render.py", copy_proj, "--fast", "--json").stdout)
+        self.assertEqual(data["stages"], ["clips"])
+        self.assertClose(probe(str(OUT / "render_copy.mp4"))["duration"], 2.0, 0.3)
+        # refusals: each names its cause and exits non-zero
+        cases = {
+            "no_project": ([], "give a project.json"),
+            "unreadable": ([OUT / "render_missing.json"], "cannot read project"),
+            "empty_clips": ([self._proj("render_e1.json", {"clips": []})], "clips is empty"),
+            "captions_key": ([self._proj("render_e2.json", {"clips": full["clips"], "captions": {"size": 20}}), "--dry-run"], "captions needs text, srt or ass"),
+            "graphics_key": ([self._proj("render_e3.json", {"clips": full["clips"], "graphics": [{"name": "x"}]}), "--dry-run"], "needs a template"),
+            "overlay_key": ([self._proj("render_e4.json", {"clips": full["clips"], "overlays": [{"opacity": 1}]}), "--dry-run"], "needs image or text"),
+            "child_failed": ([self._proj("render_e5.json", {"clips": [{"src": "source.mp4", "in": "not-a-time", "out": 2}]}), "--dry-run"], "cut.py failed"),
+        }
+        for name, (argv, message) in cases.items():
+            proc = script("render.py", *argv, expect_fail=True)
+            self.assertIn(message, proc.stderr, f"{name}: {proc.stderr[-400:]}")
+
+    def _proj(self, name, body):
+        p = OUT / name
+        p.write_text(json.dumps(dict({"output": name.replace(".json", ".mp4")}, **body)), encoding="utf-8")
+        return p
+
     def test_render_default_work_dir_is_unique_per_process(self):
         """The default work dir name came only from the output path (e.g. "out_work"), no PID or
         timestamp -- two concurrent render.py runs targeting the same output (a batch.py "project"

--- a/tests/test_all.py
+++ b/tests/test_all.py
@@ -1784,6 +1784,37 @@ class FFmpegSkillTests(unittest.TestCase):
         cap_files = sorted(p.name for p in out.glob("clip*_cap.mp4"))
         self.assertEqual(len(cap_files), 2, f"expected two distinct 'caption' outputs, got {cap_files}")
 
+    def test_verify_full_plan_hdr_surround_broken_file_and_timeout(self):
+        """verify.py's non---quick plan (overlay, look sheet, probe --analyze, loudness, silence,
+        color --to-sdr + the HDR-preserved check on an HDR file, --downmix on >2ch audio), the
+        "ffprobe failed" row for a file that is not media, the plain-text report path (no --json)
+        and the per-step timeout were all unexercised: the two existing verify tests only ran
+        --quick --json on good files (#147). A collection with one HDR10 file, one 5.1 file and
+        one file of garbage bytes exits 1 (the garbage), while every step on the two real files
+        still passes."""
+        folder = OUT / "verify_full"
+        folder.mkdir(exist_ok=True)
+        (folder / Path(self.hdr).name).write_bytes(Path(self.hdr).read_bytes())
+        (folder / Path(self.surround).name).write_bytes(Path(self.surround).read_bytes())
+        (folder / "broken.mp4").write_bytes(b"this is not a media file\n" * 64)
+        out = OUT / "verify_full_out"
+        report = OUT / "verify_full.md"
+        proc = script("verify.py", folder, "--seconds", "2", "--keep", "--out", out, "--report", report, expect_fail=True)
+        text = report.read_text(encoding="utf-8")
+        self.assertIn(text.strip(), proc.stdout.strip(), "without --json the report is printed to stdout")
+        self.assertIn("| probe | FAIL | 0s | ffprobe failed |", text)
+        for step in ("overlay text", "look sheet", "probe analyze", "loudness measure", "silence list",
+                     "color to-sdr", "hdr preserved", "audio downmix", "export x"):
+            self.assertIn(f"| {step} | PASS |", text, f"{step} missing or failed:\n{text}")
+        self.assertNotIn("| FAIL |", text.replace("| probe | FAIL | 0s | ffprobe failed |", ""))
+        self.assertTrue((out / f"{Path(self.hdr).stem}_sdr.mp4").exists())
+        self.assertTrue((out / f"{Path(self.surround).stem}_st.mp4").exists())
+        # a per-step timeout is reported per step, never raised
+        data = json.loads(script("verify.py", self.src, "--quick", "--timeout", "0.01", "--json", expect_fail=True).stdout)
+        timed_out = [s for f in data["files"] for s in f["steps"] if s["error"].startswith("timeout after")]
+        self.assertTrue(timed_out, data)
+        self.assertEqual(data["failed"], len(timed_out))
+
     def test_progress_and_fast_flags(self):
         out = OUT / "prog.mp4"
         proc = script("fit.py", self.src, "--duration", "6", "--fast", "--progress", "-o", out)

--- a/tests/test_contract.py
+++ b/tests/test_contract.py
@@ -818,6 +818,48 @@ class ContractTests(unittest.TestCase):
             unknown = self._rpc([{"jsonrpc": "2.0", "id": 3, "method": "tools/call", "params": {"name": "_contract", "arguments": {}}}], root=root)[0]
             self.assertTrue(unknown["result"]["isError"], "internal scripts are not callable")
 
+    def test_mcp_server_error_paths_raw_argv_and_call_helper(self):
+        """The stdio loop and tools/call were only tested on the happy path (#147). Pinned here:
+        a non-JSON line, a JSON scalar, an id-less notification and a params-that-is-not-an-object
+        request never kill the server; an unknown method is -32601 and any other handler error is
+        -32000; a tool that exits non-zero comes back as isError with the stderr tail, never as a
+        transport error; the raw `argv` form appends --json only for tools that need it (probe and
+        look are exempt) and never after --help; and the `--call` debugging helper prints the same
+        result object."""
+        proc = subprocess.run([sys.executable, str(ROOT / "mcp" / "server.py")],
+                              input="not json at all\n42\n[1, 2]\n"
+                                    + json.dumps({"jsonrpc": "2.0", "method": "ping"}) + "\n"
+                                    + json.dumps({"jsonrpc": "2.0", "id": 1, "method": "ping"}) + "\n"
+                                    + json.dumps({"jsonrpc": "2.0", "id": 2, "method": "nope"}) + "\n"
+                                    + json.dumps({"jsonrpc": "2.0", "id": 3, "method": "tools/call", "params": "x"}) + "\n"
+                                    + json.dumps({"jsonrpc": "2.0", "id": 4, "method": "tools/call",
+                                                  "params": {"name": "cut", "arguments": {"input": str(self.out("missing.mp4")), "start": "0", "end": "1", "output": str(self.out("never.mp4"))}}}) + "\n"
+                                    + json.dumps({"jsonrpc": "2.0", "id": 5, "method": "tools/call",
+                                                  "params": {"name": "probe", "arguments": {"argv": [str(self.wav)]}}}) + "\n"
+                                    + json.dumps({"jsonrpc": "2.0", "id": 6, "method": "tools/call",
+                                                  "params": {"name": "silence", "arguments": {"argv": [str(self.src), "--list"]}}}) + "\n",
+                              stdout=subprocess.PIPE, stderr=subprocess.PIPE, text=True)
+        self.assertEqual(proc.returncode, 0, proc.stderr)
+        resps = {r["id"]: r for r in (json.loads(l) for l in proc.stdout.strip().splitlines())}
+        self.assertEqual(sorted(resps), [1, 2, 3, 4, 5, 6], "garbage and notifications produce no response; nothing else is lost")
+        self.assertEqual(resps[1]["result"], {})
+        self.assertEqual(resps[2]["error"]["code"], -32601)
+        self.assertEqual(resps[3]["error"]["code"], -32000)
+        self.assertTrue(resps[4]["result"]["isError"])
+        self.assertIn("cut failed (exit", resps[4]["result"]["content"][0]["text"])
+        self.assertEqual(resps[5]["result"]["structuredContent"]["audio"]["codec"], "pcm_s16le")
+        self.assertIn("structuredContent", resps[6]["result"], "--json appended for a JSON tool in raw argv form")
+        # the raw form appends --json exactly for the tools that need it to speak JSON
+        self.assertEqual(mcp_server.build_argv("probe", {"argv": [str(self.wav)]}), [str(self.wav)])
+        self.assertEqual(mcp_server.build_argv("silence", {"argv": [str(self.src), "--list"]}), [str(self.src), "--list", "--json"])
+        self.assertEqual(mcp_server.build_argv("silence", {"argv": [str(self.src), "--help"]}), [str(self.src), "--help"])
+        # --call NAME JSON prints the same object the RPC returns
+        proc = sh(sys.executable, ROOT / "mcp" / "server.py", "--call", "probe", json.dumps({"inputs": [str(self.wav)]}))
+        doc = json.loads(proc.stdout)
+        self.assertEqual(doc["structuredContent"]["audio"]["codec"], "pcm_s16le")
+        proc = sh(sys.executable, ROOT / "mcp" / "server.py", "--call", "not_a_tool")
+        self.assertTrue(json.loads(proc.stdout)["isError"])
+
     def test_mcp_round_trips_built_from_the_derived_schema(self):
         listed = {t["name"]: t["inputSchema"] for t in self._rpc([{"jsonrpc": "2.0", "id": 1, "method": "tools/list"}])[0]["result"]["tools"]}
         project = self.out("mcp_project.json")


### PR DESCRIPTION
## Summary

Part of #147 (the three lowest-coverage files). No shipped code changes; tests only.

- **`verify.py` (82%)** was only exercised with `--quick --json` on good files. New test runs the full plan on one HDR10 file, one 5.1 file and one file of garbage bytes with `--keep --out --report` and no `--json`: overlay, look sheet, probe --analyze, loudness, silence, `color --to-sdr` + the HDR-preserved check, `--downmix` all PASS; the garbage file yields exactly one `ffprobe failed` FAIL row and exit code 1; the plain-text report is printed to stdout. A second run with `--timeout 0.01` proves a timeout is reported per step, never raised.
- **`mcp/server.py` (83%)** stdio loop and `tools/call` were only tested on the happy path. New test feeds a non-JSON line, a JSON scalar, an id-less notification and a params-that-is-not-an-object request (none kill the server), an unknown method (-32601), a handler error (-32000), a tool that exits non-zero (isError with the stderr tail), the raw `argv` form (`--json` appended only for tools that need it, never after `--help`), and the `--call` debugging helper.

`render.py` (80%) follows in a second commit on this PR once the coverage run over the current tree finishes and names its missing lines.

## Test plan

- [x] Both new tests pass locally (Ubuntu, FFmpeg 6.1): verify test 67 s, MCP test 5 s
- [ ] CI green on all four jobs
- [ ] Coverage re-measured after merge: verify.py and mcp/server.py ≥ 90%
- [ ] `chore(` title → no release on merge

Refs #147, #148.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013tPrsGXLuaGU7t643QNUZs

---
_Generated by [Claude Code](https://claude.ai/code/session_013tPrsGXLuaGU7t643QNUZs)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Tests**
  - Expanded end-to-end coverage for verification plans, HDR processing, audio handling, rendering stages, dry-run behavior, timeouts, and error reporting.
  - Added coverage for malformed and valid JSON-RPC requests, tool failures, raw argument handling, and debugging output.
  - These checks improve confidence in consistent validation, rendering, and server responses across edge cases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->