### PR TITLE
Add a Claude Code plugin manifest so the repo installs with `claude plugin install`

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,0 +1,19 @@
+{
+  "name": "ffmpeg-skill",
+  "description": "Local FFmpeg video/audio editing for coding agents: 40 tools with a machine-readable contract, capability detection, probe-first / verify-last workflow. No cloud, no API keys.",
+  "version": "1.0.4",
+  "author": {
+    "name": "kajisho5",
+    "url": "https://github.com/kajisho5"
+  },
+  "homepage": "https://github.com/kajisho5/ffmpeg-skill",
+  "repository": "https://github.com/kajisho5/ffmpeg-skill",
+  "license": "MIT",
+  "keywords": [
+    "ffmpeg",
+    "video",
+    "audio",
+    "skill",
+    "mcp"
+  ]
+}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,7 +11,7 @@ name: release
 #     (.github/scripts/resolve_version.py: minor/feature/enhancement -> minor,
 #     patch/fix/bug -> patch, unlabeled -> patch, chore/ci/docs/dependencies
 #     only -> nothing to release, major -> refused), bumps
-#     package.json and docs/contract.md to that version, writes a CHANGELOG.md
+#     package.json, .claude-plugin/plugin.json and docs/contract.md to that version, writes a CHANGELOG.md
 #     section listing those merged PRs, and pushes that bump commit to main
 #     itself before continuing -- see "Auto-bump" below.
 #   - If a PR *did* bump package.json's version by hand (and, by this repo's
@@ -130,6 +130,12 @@ jobs:
           assert pkg != pkg_new, "package.json version field not found/replaced"
           pkg_path.write_text(pkg_new, encoding="utf-8")
 
+          plugin_path = root / ".claude-plugin" / "plugin.json"
+          plugin = plugin_path.read_text(encoding="utf-8")
+          plugin_new = re.sub(r'("version":\s*")[^"]+(")', rf'\g<1>{new}\g<2>', plugin, count=1)
+          assert plugin != plugin_new, ".claude-plugin/plugin.json version field not found/replaced"
+          plugin_path.write_text(plugin_new, encoding="utf-8")
+
           contract_path = root / "docs" / "contract.md"
           contract = contract_path.read_text(encoding="utf-8")
           contract_path.write_text(contract.replace(old, new), encoding="utf-8")
@@ -167,7 +173,7 @@ jobs:
 
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
-          git add package.json docs/contract.md CHANGELOG.md
+          git add package.json .claude-plugin/plugin.json docs/contract.md CHANGELOG.md
           git commit -m "chore(release): bump version to ${NEW_VERSION}"
           git push origin HEAD:main
 

--- a/README.md
+++ b/README.md
@@ -356,6 +356,14 @@ npx ffmpeg-skill --dir ./my-skills
 npx ffmpeg-skill --uninstall  # remove from the selected targets (--codex also clears the older ~/.codex/skills location)
 ```
 
+As a Claude Code plugin (no Node needed, updates with `claude plugin update`):
+
+```bash
+claude plugin install kajisho5/ffmpeg-skill
+```
+
+The plugin namespaces the skill as `ffmpeg-skill:ffmpeg-skill`; the manifest is [.claude-plugin/plugin.json](.claude-plugin/plugin.json) and its version follows every release automatically.
+
 Without Node: clone this repository and copy `SKILL.md`, `scripts/`, `references/` and `mcp/` into your agent's skills directory.
 
 After installing:

--- a/docs/contract.md
+++ b/docs/contract.md
@@ -30,7 +30,7 @@ tag, not by tracking `main` — see README, "Development", "Releasing".
 
 The prose tool count in this file, README, `SKILL.md` and `package.json`'s description is
 not generated (it reads naturally in a sentence), so `tests/test_contract.py`'s
-`test_docs_tool_count_matches_the_real_tool_list` checks all four against the real count
+`test_docs_tool_count_matches_the_real_tool_list` checks all five against the real count
 from `scripts/` on every CI run instead — a stale count fails a test rather than drifting
 silently. (`SKILL.md` was added to that check after its "the 28 scripts" sat stale through
 twelve tool additions while the other three files were correct.)

--- a/tests/test_contract.py
+++ b/tests/test_contract.py
@@ -167,6 +167,7 @@ class ContractTests(unittest.TestCase):
             # "the N scripts" -- it sat at a stale 28 for weeks while the three above were
             # correct, precisely because this check didn't look at it or at that wording.
             (ROOT / "SKILL.md", re.compile(r"\b(\d+)\s+(?:public )?(?:tools|scripts)\b")),
+            (ROOT / ".claude-plugin" / "plugin.json", re.compile(r"\b(\d+)\s+tools\b")),
         ]
         for path, pattern in checks:
             text = path.read_text(encoding="utf-8")
@@ -185,6 +186,21 @@ class ContractTests(unittest.TestCase):
         self.assertIn("Edit video and audio", self.contract["skill"]["description"])
         for t in self.contract["tools"]:
             self.assertEqual(t["version"], pkg["version"])
+
+    def test_claude_plugin_manifest_matches_package_and_skill(self):
+        """.claude-plugin/plugin.json makes the repo installable with `claude plugin install
+        kajisho5/ffmpeg-skill` (#142); a single-skill plugin may keep SKILL.md at its root. Its
+        version must track package.json (release.yml's auto-bump rewrites both), its name must
+        equal SKILL.md's frontmatter name (the plugin namespaces the skill as name:name), and it
+        must be valid JSON with only the documented top-level fields."""
+        manifest = json.loads((ROOT / ".claude-plugin" / "plugin.json").read_text(encoding="utf-8"))
+        pkg = json.loads((ROOT / "package.json").read_text(encoding="utf-8"))
+        self.assertEqual(manifest["version"], pkg["version"])
+        self.assertEqual(manifest["name"], pkg["name"])
+        skill_name = re.search(r"(?m)^name:\s*(\S+)", (ROOT / "SKILL.md").read_text(encoding="utf-8")).group(1)
+        self.assertEqual(manifest["name"], skill_name)
+        self.assertTrue(set(manifest) <= {"name", "version", "description", "author", "homepage", "repository", "license", "keywords"}, sorted(manifest))
+        self.assertTrue(re.fullmatch(r"[a-z0-9-]+", manifest["name"]))
 
     def test_docs_contract_example_version_matches_package_json(self):
         """docs/contract.md's illustrative JSON example of the Skill object hand-copies a


### PR DESCRIPTION
## Summary

#142: distribute as a Claude Code plugin without moving anything.

- **`.claude-plugin/plugin.json`** (name, version, description, author, homepage/repository, license, keywords). Per the Claude Code plugin docs (plugins.md, plugins-reference.md, plugin-marketplaces.md — checked by a docs lookup, not from memory): only `name` is required; a single-skill plugin may keep `SKILL.md` at the plugin root; direct `claude plugin install kajisho5/ffmpeg-skill` needs no marketplace.json. The skill is namespaced `ffmpeg-skill:ffmpeg-skill`.
- **`release.yml`**: the auto-bump rewrites the manifest version next to package.json / docs/contract.md and includes it in the bump commit, so the plugin version never drifts from npm.
- **Test**: manifest version == package.json version; name == SKILL.md frontmatter name == package name; only documented top-level fields; the manifest's "40 tools" joins the tool-count drift test (now five surfaces).
- **README "Install"**: the plugin command and the namespaced name.

Title starts with `Add` → autolabeled `feature` → this merge releases **1.1.0** (minor). That is intended: a new install channel is a feature, and the release itself exercises the manifest bump path for the first time.

## Test plan

- [x] `yaml.safe_load` on release.yml; embedded bump script `ast.parse`d
- [x] New manifest test + tool-count drift test pass locally
- [ ] CI green
- [ ] After merge: release run publishes 1.1.0 and the bump commit updates `.claude-plugin/plugin.json` to 1.1.0; "Verify the publish landed" passes
- [ ] `claude plugin install kajisho5/ffmpeg-skill` on a real machine (#143 territory; I cannot run Claude Code here)

Refs #142, #148.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013tPrsGXLuaGU7t643QNUZs

---
_Generated by [Claude Code](https://claude.ai/code/session_013tPrsGXLuaGU7t643QNUZs)_