### PR TITLE
docs: README badges for CodeQL, downloads, stars, last commit and tested FFmpeg/Python versions

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,9 +13,13 @@
 
 <p align="center">
   <a href="https://github.com/kajisho5/ffmpeg-skill/actions/workflows/ci.yml"><img src="https://github.com/kajisho5/ffmpeg-skill/actions/workflows/ci.yml/badge.svg" alt="tests"></a>
+  <a href="https://github.com/kajisho5/ffmpeg-skill/actions/workflows/codeql.yml"><img src="https://github.com/kajisho5/ffmpeg-skill/actions/workflows/codeql.yml/badge.svg" alt="CodeQL"></a>
   <a href="https://www.npmjs.com/package/ffmpeg-skill"><img src="https://img.shields.io/npm/v/ffmpeg-skill" alt="npm"></a>
-  <img src="https://img.shields.io/badge/python-3.9%2B-blue" alt="Python 3.9+">
-  <img src="https://img.shields.io/badge/ffmpeg-5.0%2B-orange" alt="FFmpeg 5.0+">
+  <a href="https://www.npmjs.com/package/ffmpeg-skill"><img src="https://img.shields.io/npm/dm/ffmpeg-skill" alt="npm downloads"></a>
+  <a href="https://github.com/kajisho5/ffmpeg-skill/stargazers"><img src="https://img.shields.io/github/stars/kajisho5/ffmpeg-skill" alt="GitHub stars"></a>
+  <a href="https://github.com/kajisho5/ffmpeg-skill/commits/main"><img src="https://img.shields.io/github/last-commit/kajisho5/ffmpeg-skill" alt="last commit"></a>
+  <img src="https://img.shields.io/badge/python-3.9%20%7C%203.13-blue" alt="Python 3.9 and 3.13 tested">
+  <a href="#ffmpeg-compatibility"><img src="https://img.shields.io/badge/ffmpeg-5.1%20%7C%206.1%20%7C%207.1%20%7C%208%20%7C%209%20tested-orange" alt="FFmpeg 5.1, 6.1, 7.1, 8 and 9 tested in CI"></a>
   <a href="LICENSE"><img src="https://img.shields.io/badge/license-MIT-green" alt="MIT"></a>
   <a href="https://github.com/sponsors/kajisho5"><img src="https://img.shields.io/badge/sponsor-%E2%9D%A4-ea4aaa?logo=githubsponsors" alt="Sponsor"></a>
 </p>


### PR DESCRIPTION
## What

Badge row in the README:

- Added: CodeQL workflow status, npm monthly downloads, GitHub stars, last commit.
- Replaced `FFmpeg 5.0+` (a minimum nobody tests) with the versions CI actually runs: `5.1 | 6.1 | 7.1 | 8 | 9 tested`, linking to the FFmpeg compatibility section.
- Replaced `Python 3.9+` with `3.9 | 3.13` (the two ends CI runs).

Nothing else changes; the prose minimum ("FFmpeg 5.0 or later") is untouched. Docs only, no release.

## Verification

Docs-related contract tests (tool count, README/SKILL consistency) pass locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013tPrsGXLuaGU7t643QNUZs

---
_Generated by [Claude Code](https://claude.ai/code/session_013tPrsGXLuaGU7t643QNUZs)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Updated the README with additional project status and popularity badges.
  - Expanded supported and tested Python version information.
  - Expanded the list of tested FFmpeg versions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->