### PR TITLE
fix(release): fold hand-written Unreleased notes into the bump instead of asserting the placeholder

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -166,9 +166,18 @@ jobs:
 
           changelog_path = root / "CHANGELOG.md"
           changelog = changelog_path.read_text(encoding="utf-8")
-          anchor = "## Unreleased\n\n(nothing yet)\n\n"
-          assert anchor in changelog, "CHANGELOG.md's Unreleased anchor not found"
-          changelog_path.write_text(changelog.replace(anchor, anchor + section, 1), encoding="utf-8")
+          # Whatever sits under "## Unreleased" (hand-written bullets from the merged PRs, or the
+          # placeholder "(nothing yet)") moves into the new version's section, ahead of the
+          # generated commit-subject bullets, and the placeholder is put back. The anchor used to
+          # be the literal "(nothing yet)" line, so a PR that wrote real notes there broke the
+          # bump step (1.4.1's first run).
+          m = re.search(r"## Unreleased\n(.*?)(?=^## )", changelog, re.S | re.M)
+          assert m, "CHANGELOG.md has no '## Unreleased' section followed by a version heading"
+          unreleased = m.group(1).strip()
+          if unreleased and unreleased != "(nothing yet)":
+              section = section.replace(f"since {old}._\n\n", f"since {old}._\n\n{unreleased}\n", 1)
+          changelog = changelog[:m.start()] + "## Unreleased\n\n(nothing yet)\n\n" + section + changelog[m.end():]
+          changelog_path.write_text(changelog, encoding="utf-8")
           PY
 
           git config user.name "github-actions[bot]"

--- a/references/process-pitfalls.md
+++ b/references/process-pitfalls.md
@@ -158,3 +158,13 @@ inputs (or `Unexpected input(s)` in the first log) before trusting a parameter, 
 any step whose output decides an irreversible action as something to unit-test with fixed
 inputs, not something to confirm by reading its YAML. And watch the first real run's
 *effect* (tags, npm), which is how both incidents were actually noticed.
+
+### The release bump step required the literal `(nothing yet)` line under `## Unreleased`
+
+Found on the first run after #163 (2026-09-11). `release.yml`'s auto-bump located the CHANGELOG
+insertion point with `assert "## Unreleased\n\n(nothing yet)\n\n" in changelog`. #163 did the
+natural thing and wrote its notes under Unreleased, so the bump step failed on the assert
+before the push, the tag or the publish -- a clean no-op, but a red run and no release. The
+script now takes whatever sits under Unreleased into the new version's section and puts the
+placeholder back, so hand-written notes are welcome there. Lesson: an anchor that is also
+prose will be edited; anchor on the heading, not on the placeholder text.


### PR DESCRIPTION
## What

The release run for #163 failed in "Auto-bump" with `CHANGELOG.md's Unreleased anchor not found` before the push, tag or publish: the script anchored on the literal `## Unreleased\n\n(nothing yet)\n\n`, and #163 had written real notes under Unreleased. Nothing was published and main is untouched (still 1.4.0), so this is a clean no-op to recover from.

- `release.yml`: the bump now takes whatever sits under `## Unreleased` into the new version's section (ahead of the generated commit-subject bullets) and restores the `(nothing yet)` placeholder. Hand-written notes there are welcome from now on.
- `references/process-pitfalls.md`: the lesson (anchor on the heading, not on placeholder prose).

Simulated on the current CHANGELOG: the two #163 bullets land under `## 1.4.1` followed by the commit line, Unreleased goes back to the placeholder.

Title starts with `fix` → this merge releases 1.4.1 carrying #163. It is also the first release under the active main ruleset, so the bump push is the thing to watch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013tPrsGXLuaGU7t643QNUZs

---
_Generated by [Claude Code](https://claude.ai/code/session_013tPrsGXLuaGU7t643QNUZs)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved release note handling so existing unreleased notes are preserved and included in the appropriate version entry.
  - Reset the unreleased section consistently after a release, preventing release note content from being lost or causing release updates to stop unexpectedly.

- **Documentation**
  - Added guidance describing release note handling pitfalls and the updated behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->