### PR TITLE
fix(color): --correct no longer desaturates bt709-tagged sources

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ## Unreleased
 
+- `color.py --correct` no longer desaturates bt709-tagged sources: the RGB stages are wrapped in explicit, matching YUV<->RGB conversions instead of libavfilter's auto-inserted pair, which used bt709 one way and bt601 the other (#159).
 - Every tool takes `--timeout SECONDS` (default 1800, `FFMPEG_SKILL_TIMEOUT`): a single ffmpeg run past the limit is killed, its partial output removed, and the failure reported as `kind: timeout` (exit 124) instead of hanging the caller.
 - Every tool takes `--overwrite`. An output path that already exists (and was not written by this run) now prints a warning; `FFMPEG_SKILL_NO_OVERWRITE=1` makes it a refusal today, and 2.0 will refuse by default.
 

--- a/scripts/color.py
+++ b/scripts/color.py
@@ -112,24 +112,44 @@ def correction_chain(args: argparse.Namespace) -> str:
         die(f"--levels-out-black {out_black} must be less than --levels-out-white {out_white}")
 
     gm, rm, bm = -tint, tint / 2.0, tint / 2.0
-    terms = [
+    rgb = [
         f"exposure=exposure={exposure:g}",
         f"colortemperature=temperature={temperature:g}",
         f"colorbalance=rs={lift:g}:gs={lift:g}:bs={lift:g}:rm={rm:g}:gm={gm:g}:bm={bm:g}:rh={gain:g}:gh={gain:g}:bh={gain:g}",
-        f"eq=contrast={contrast:g}:saturation={saturation:g}:gamma={gamma:g}",
     ]
+    terms = [_rgb_stage(rgb), f"eq=contrast={contrast:g}:saturation={saturation:g}:gamma={gamma:g}"]
+    rgb2 = []
     if (in_black, in_white, out_black, out_white) != (0, 255, 0, 255):
         rimin, rimax = in_black / 255.0, in_white / 255.0
         romin, romax = out_black / 255.0, out_white / 255.0
-        terms.append(
+        rgb2.append(
             f"colorlevels=rimin={rimin:g}:gimin={rimin:g}:bimin={rimin:g}:"
             f"rimax={rimax:g}:gimax={rimax:g}:bimax={rimax:g}:"
             f"romin={romin:g}:gomin={romin:g}:bomin={romin:g}:"
             f"romax={romax:g}:gomax={romax:g}:bomax={romax:g}"
         )
     if args.curves:
-        terms.append(f"curves=preset={args.curves}")
+        rgb2.append(f"curves=preset={args.curves}")
+    if rgb2:
+        terms.append(_rgb_stage(rgb2))
     return ",".join(terms)
+
+
+def _rgb_stage(filters: list) -> str:
+    """Wrap a run of RGB-only filters in explicit, matching YUV<->RGB conversions.
+
+    exposure/colortemperature/colorbalance/colorlevels/curves take RGB, so libavfilter inserts a
+    swscale conversion on each side. Left to itself, the way in honours the frame's colour tag
+    (bt709 on any camera or export.py file) while the way back uses swscale's default matrix
+    (bt601): on a bt709-tagged source an all-defaults --correct came out 26 dB PSNR from its
+    input and ~8 % less saturated (#159). Untagged sources never showed it because both legs
+    then fall back to bt601 and cancel. Pinning both legs to the same matrix restores the
+    identity on every source (39 dB, the same as an untagged one always got); bt601 on both
+    sides measured better than bt709 on both (34 dB) because swscale's 601 path round-trips
+    8-bit 4:2:0 more exactly. The matrix here is only the working space of the conversion pair,
+    never a tag: the output carries the encoder's BT.709 tags as before."""
+    return ("scale=in_color_matrix=bt601,format=gbrpf32le," + ",".join(filters)
+            + ",scale=out_color_matrix=bt601,format=yuv420p")
 
 
 def hdr_to_sdr_chain(meta: dict, tonemap: str, peak: float, desat: float) -> str:

--- a/tests/test_all.py
+++ b/tests/test_all.py
@@ -1426,6 +1426,31 @@ class FFmpegSkillTests(unittest.TestCase):
         script("color.py", self.src, "--lut", lut, "--lut-strength", "2.5", "-o", OUT / "lut_oob.mp4", expect_fail=True)
         script("color.py", self.src, "--lut", lut, "--lut-strength", "-1", "-o", OUT / "lut_oob2.mp4", expect_fail=True)
 
+    def test_color_correct_identity_holds_on_a_bt709_tagged_source(self):
+        """#159: the identity test below only ever ran on the untagged synthetic source. On a
+        source *tagged* bt709 (any camera file, anything export.py wrote) an all-defaults
+        --correct came back 26 dB PSNR and ~8 % less saturated, because libavfilter's auto-
+        inserted swscale legs around the RGB filters disagreed: yuv->rgb honoured the frame's
+        bt709 tag, rgb->yuv used the default bt601. Both legs are now pinned to one matrix, so
+        the result is the same on a tagged and an untagged copy of the same pixels, on FFmpeg
+        5.1 through 8.1 (measured 39.5 dB on all four)."""
+        tagged = OUT / "correct_src709.mp4"
+        sh("ffmpeg", "-y", "-hide_banner", "-loglevel", "error", "-i", str(self.src), "-t", "3",
+           "-vf", "setparams=colorspace=bt709:color_primaries=bt709:color_trc=bt709:range=tv",
+           "-c:v", "libx264", "-preset", "veryfast", "-crf", "12", "-colorspace", "bt709", "-color_primaries", "bt709", "-color_trc", "bt709", "-an", str(tagged))
+        self.assertEqual(probe(str(tagged))["video"]["color_space"], "bt709")
+        untagged = OUT / "correct_srcU.mp4"
+        sh("ffmpeg", "-y", "-hide_banner", "-loglevel", "error", "-i", str(self.src), "-t", "3", "-c:v", "libx264", "-preset", "veryfast", "-crf", "12", "-an", str(untagged))
+        results = {}
+        for name, src in (("tagged", tagged), ("untagged", untagged)):
+            out = OUT / f"correct_identity_{name}.mp4"
+            data = json.loads(script("color.py", src, "--correct", "--preset", "veryfast", "-o", out, "--json").stdout)
+            m = data["measurements"]
+            self.assertAlmostEqual(m["input"]["saturation_avg"], m["output"]["saturation_avg"], delta=2.5, msg=name)
+            results[name] = self._psnr(src, out)
+            self.assertGreater(results[name], 36, f"{name}: an all-defaults --correct must be near-identity, got {results[name]:.1f} dB")
+        self.assertAlmostEqual(results["tagged"], results["untagged"], delta=1.0, msg="the colour tag must not change what --correct does to the pixels")
+
     def test_color_correct_defaults_are_near_identity(self):
         out = OUT / "correct_neutral.mp4"
         data = json.loads(script("color.py", self.src, "--correct", "--preset", "veryfast", "-o", out, "--json").stdout)


### PR DESCRIPTION
## What

Fixes #159. The RGB stages of `--correct` (exposure, colortemperature, colorbalance; colorlevels and curves when asked for) let libavfilter insert the YUV↔RGB conversions, and on a bt709-tagged source the two legs disagreed: yuv→rgb honoured the frame's bt709 tag, rgb→yuv used swscale's default bt601. An all-defaults `--correct` came back 26 dB PSNR and ~8 % less saturated on any camera or `export.py` file. Untagged sources never showed it because both legs then fell back to bt601 and cancelled, which is why the existing identity test (untagged synthetic source only) passed.

Each run of RGB filters is now wrapped in explicit `scale=in_color_matrix=…,format=gbrpf32le,…,scale=out_color_matrix=…,format=yuv420p` pinned to one matrix. bt601 on both legs measured 39.5 dB on tagged and untagged copies of the same pixels; bt709 on both legs only 34 dB (swscale's 709 path round-trips 8-bit 4:2:0 less exactly), so bt601 is the working space. It is only the conversion pair's working space, never a tag: the output carries the encoder's BT.709 tags as before.

| source | before | after |
|---|---|---|
| bt709-tagged, `--correct` defaults | 26.0 dB, saturation 111.9 → 102.2 | 39.5 dB, 111.9 → 110.0 |
| untagged, same pixels | 39.5 dB, 111.9 → 110.0 | 39.5 dB, 111.9 → 110.0 |

Same numbers on FFmpeg 5.1.1, 6.1.1, 7.1.1 and 8.1.2 (conda-forge / static builds locally).

## Verification

New `test_color_correct_identity_holds_on_a_bt709_tagged_source`: builds a tagged and an untagged 3 s copy of the fixture, asserts PSNR > 36 dB and saturation within 2.5 for both, and that the two results agree within 1 dB. All 10 `color_correct` tests green locally.

Title starts with `fix` → patch release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013tPrsGXLuaGU7t643QNUZs

---
_Generated by [Claude Code](https://claude.ai/code/session_013tPrsGXLuaGU7t643QNUZs)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved color correction for BT.709-tagged video sources.
  * Prevented unintended desaturation and color shifts during correction.
* **Tests**
  * Added coverage confirming corrected BT.709-tagged sources preserve color and remain consistent with untagged sources.
* **Documentation**
  * Added an Unreleased changelog entry describing the color correction fix.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->