### PR TITLE
ci(release): push the bump commit with RELEASE_PUSH_TOKEN so the main ruleset lets it through

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -35,6 +35,17 @@ name: release
 # the auto-bump commit below is safe to push straight from this job without
 # looping: it never starts a second run of this workflow, this same run just
 # continues on past it with the new version.
+#
+# main is protected by a ruleset (PR required, 8 status checks) that the
+# built-in GITHUB_TOKEN cannot bypass (GitHub Actions is not an accepted
+# bypass actor; #137). The bump commit is therefore pushed with the
+# RELEASE_PUSH_TOKEN secret when it exists: a fine-grained PAT of a repository
+# admin (Contents: read/write on this repo only), whose "Repository admin"
+# bypass lets the push through. A PAT push DOES trigger workflows, unlike
+# GITHUB_TOKEN, so the bump commit message carries [skip ci]: the tag, the
+# GitHub Release and the npm publish all happen in this same run, and a second
+# run on the bump commit would only find the tag already present. Without the
+# secret the push falls back to GITHUB_TOKEN (works on an unprotected main).
 
 on:
   push:
@@ -59,6 +70,7 @@ jobs:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
+          token: ${{ secrets.RELEASE_PUSH_TOKEN || secrets.GITHUB_TOKEN }}
 
       - name: Decide whether an automatic version bump is needed
         id: setup
@@ -174,7 +186,7 @@ jobs:
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
           git add package.json .claude-plugin/plugin.json docs/contract.md CHANGELOG.md
-          git commit -m "chore(release): bump version to ${NEW_VERSION}"
+          git commit -m "chore(release): bump version to ${NEW_VERSION} [skip ci]"
           git push origin HEAD:main
 
       - name: Check whether this version is already released

--- a/references/process-pitfalls.md
+++ b/references/process-pitfalls.md
@@ -158,3 +158,15 @@ inputs (or `Unexpected input(s)` in the first log) before trusting a parameter, 
 any step whose output decides an irreversible action as something to unit-test with fixed
 inputs, not something to confirm by reading its YAML. And watch the first real run's
 *effect* (tags, npm), which is how both incidents were actually noticed.
+
+### The built-in GITHUB_TOKEN cannot push the release bump through a ruleset
+
+Found on the first release after the main ruleset went active (2026-09-11, run for #166):
+`git push origin HEAD:main` from release.yml was declined with GH013 ("Changes must be made
+through a pull request", "8 of 8 required status checks are expected"). GitHub Actions cannot
+be added as a ruleset bypass actor (the import rejects the actor, the UI does not list it), so
+the bump push now uses the `RELEASE_PUSH_TOKEN` secret -- a fine-grained PAT of a repository
+admin with Contents: read/write on this repo -- whose "Repository admin" bypass applies. A PAT
+push triggers workflows (GITHUB_TOKEN's do not), so the bump commit carries `[skip ci]`; the
+tag, Release and npm publish all happen in the originating run. Rotate the PAT before it
+expires or the next release fails at the same step, cleanly, before anything is published.


### PR DESCRIPTION
## What

Issue #137, option 2. The first release under the active main ruleset (run for #166) was declined at the bump push:

```
remote: error: GH013: Repository rule violations found for refs/heads/main.
remote: - Changes must be made through a pull request.
remote: - 8 of 8 required status checks are expected.
```

GitHub Actions cannot be a ruleset bypass actor (import rejects it, the UI does not list it), so:

- `actions/checkout` uses `secrets.RELEASE_PUSH_TOKEN` when present (falls back to `GITHUB_TOKEN`). The secret is a fine-grained PAT of a repository admin with **Contents: read and write** on this repository only; the ruleset's "Repository admin" bypass then applies to the push.
- The bump commit message gains `[skip ci]`: a PAT push triggers workflows (GITHUB_TOKEN's do not), and the tag, GitHub Release and npm publish all happen in the originating run anyway.
- `references/process-pitfalls.md` records it, including the PAT-expiry failure mode (fails cleanly at the same step, nothing published).

## Before merging

The `RELEASE_PUSH_TOKEN` repository secret must exist. Merging this PR (a `ci` change, no release of its own) still triggers `release.yml` on main, and the resolver will see the unreleased `fix` commits (#163, #166) → 1.4.1 → bump push with the PAT.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013tPrsGXLuaGU7t643QNUZs

---
_Generated by [Claude Code](https://claude.ai/code/session_013tPrsGXLuaGU7t643QNUZs)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Documented the release process for automatic version updates, including token requirements and workflow behavior.
  * Added guidance on preventing redundant workflow runs while preserving tagging, release creation, and package publishing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->