### PR TITLE
ci(release): bump on the tip of main so a merge during the run cannot reject the push

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -69,6 +69,11 @@ jobs:
     steps:
       - uses: actions/checkout@v4
         with:
+          # The tip of main, not the SHA that triggered this run: with two merges in quick
+          # succession the concurrency group queues the second run, and the first must bump on
+          # top of everything already on main or its push is rejected as non-fast-forward
+          # (1.4.2's first run, 2026-09-11: #171 landed while #167's run was still bumping).
+          ref: main
           fetch-depth: 0
           token: ${{ secrets.RELEASE_PUSH_TOKEN || secrets.GITHUB_TOKEN }}
 
@@ -196,6 +201,9 @@ jobs:
           git config user.email "github-actions[bot]@users.noreply.github.com"
           git add package.json .claude-plugin/plugin.json docs/contract.md CHANGELOG.md
           git commit -m "chore(release): bump version to ${NEW_VERSION} [skip ci]"
+          # A merge that landed during this step would still make the push non-fast-forward;
+          # replay the bump on top of it (a conflict here is real and should fail the run).
+          git pull --rebase origin main
           git push origin HEAD:main
 
       - name: Check whether this version is already released

--- a/references/process-pitfalls.md
+++ b/references/process-pitfalls.md
@@ -190,3 +190,14 @@ that merge -- no tests, no CodeQL, no release -- and the release only happened w
 merged. Describe the marker in words in PR bodies and commit messages ("the skip-CI marker"),
 or wrap it so it does not match, and after any merge that touches CI check that the push
 actually triggered the expected runs.
+
+### Two merges minutes apart: the first release run bumps on a stale main and its push is rejected
+
+Found on 1.4.2 (2026-09-11). #167 (fix) merged, then #171 (docs) a minute later while the
+release run for #167 was still bumping. The concurrency group serialises the runs, but a run
+checks out the SHA that triggered it, so the first run's bump commit sat behind #171's merge
+and `git push origin HEAD:main` was rejected as non-fast-forward. The second run (for #171)
+then found both PRs unreleased and published 1.4.2 correctly, so nothing was lost -- one red
+run and a confusing timeline. release.yml now checks out `ref: main` and rebases the bump on
+main right before pushing. Lesson: a workflow that pushes to the branch that triggered it must
+start from the branch tip, not from the triggering commit.


### PR DESCRIPTION
## What

The first release run for 1.4.2 failed at the bump push: #171 merged while #167's run was still bumping, so the run's checkout (the triggering SHA) was one commit behind `main` and the push was rejected as non-fast-forward. The run for #171 then released 1.4.2 correctly, so nothing was lost, but it was a red run and a confusing timeline.

- `actions/checkout` now uses `ref: main` so a queued run starts from the branch tip.
- The bump step runs `git pull --rebase origin main` right before the push; a genuine conflict still fails the run.
- Pitfall recorded in `references/process-pitfalls.md`.

`ci` only: no release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013tPrsGXLuaGU7t643QNUZs

---
_Generated by [Claude Code](https://claude.ai/code/session_013tPrsGXLuaGU7t643QNUZs)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Release Process**
  - Automatic releases now build from the latest `main` branch changes, including commits merged while a release was queued.
  - Version updates are synchronized with the latest branch state before being published, reducing failed release pushes.

- **Documentation**
  - Added guidance describing a past release issue and the safeguards now in place to prevent similar failures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->